### PR TITLE
WIP: Support for additional compose fields that create relationships between services

### DIFF
--- a/src/compose/service.coffee
+++ b/src/compose/service.coffee
@@ -570,14 +570,15 @@ module.exports = class Service
 				volumes[vol] = {}
 		return { binds, volumes }
 
-	toContainerConfig: =>
+	toContainerConfig: (serviceToContainer) =>
 		{ binds, volumes } = @getBindsAndVolumes()
 		tmpfs = {}
 		for dir in @tmpfs
 			tmpfs[dir] = ''
 		networkMode = @networkMode
 		if _.startsWith(networkMode, 'service:')
-			networkMode = "container:#{_.replace(networkMode, 'service:', '')}_#{@imageId}_#{@releaseId}"
+			networkModeContainerId = serviceToContainer(_.replace(networkMode, 'service:', ''))
+			networkMode = "container:#{networkModeContainerId}"
 		conf = {
 			name: "#{@serviceName}_#{@imageId}_#{@releaseId}"
 			Image: @image


### PR DESCRIPTION

Early WIP, the idea is to give each service a mapping between service names and container ids, so that services can use those for some compose fields that can specify a service name: network_mode, links, pid, and volumes_from.

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_f3o3)