### PR TITLE
Appended API example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -617,6 +617,16 @@ Response:
 }
 ```
 
+
+Remotely via the API proxy:
+```bash
+curl -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <auth token>' \
+  -d '{"uuid": "<uuid>", "method": "GET"}' \
+  "https://api.resin.io/supervisor/v2/applications/state"
+```
+
 ### GET /v2/applications/:appId/state
 
 Added in supervisor version v7.12.0.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.20",
+    "@types/dockerode": "2.5.5",
     "@types/event-stream": "^3.3.34",
     "@types/express": "^4.11.1",
     "@types/knex": "^0.14.14",


### PR DESCRIPTION
Supports #685 
https://github.com/resin-io/resin-supervisor/issues/685

Made the documentation of already existing API v2 functions a little bit more complete.
Added api proxy example to /supervisor/v2/applications/state