### PR TITLE
Rename package to balena-supervisor and push to balena repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG ARCH=amd64
 FROM resin/rpi-node:6.13.1-slim as rpi-node-base
 FROM resin/armv7hf-node:6.13.1-slim as armv7hf-node-base
 FROM resin/aarch64-node:6.13.1-slim as aarch64-node-base
+RUN [ "cross-build-start" ]
+RUN sed -i '/security.debian.org jessie/d' /etc/apt/sources.list
+RUN [ "cross-build-end" ]
 
 FROM resin/amd64-node:6.13.1-slim as amd64-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
-# resin-supervisor Makefile
+# balena-supervisor Makefile
 #
 # If you're looking for an easy way to develop on the supervisor, check ./tools/dev/dindctl, which provides a simplified interface
 # to this makefile.
 #
 # Build targets (require Docker 17.05 or greater):
-# * supervisor (default) - builds a resin-supervisor image
-# * deploy - pushes a resin-supervisor image to the registry, retrying up to 3 times
+# * supervisor (default) - builds a balena-supervisor image
+# * deploy - pushes a balena-supervisor image to the registry, retrying up to 3 times
 # * nodedeps, nodebuild - builds the node component, with the node_modules and src at /usr/src/app and /build (also includes a rootfs-overlay there)
 # * supervisor-dind: build the development docker-in-docker supervisor that run-supervisor uses (requires a SUPERVISOR_IMAGE to be available locally)
 #
 # Variables for build targets:
 # * ARCH: amd64/rpi/i386/armv7hf/armel/aarch64 architecture for which to build the supervisor - default: amd64
-# * IMAGE: image to build or deploy - default: resin/$(ARCH)-supervisor:latest
+# * IMAGE: image to build or deploy - default: balena/$(ARCH)-supervisor:latest
 # * MIXPANEL_TOKEN: (optional) default mixpanel key to embed in the supervisor image
 # * DISABLE_CACHE: if set to true, run build with no cache - default: false
 # * DOCKER_BUILD_OPTIONS: Additional options for docker build, like --cache-from parameters
 #
 # Test/development targets:
-# * run-supervisor, stop-supervisor - build and start or stop a docker-in-docker resin-supervisor (requires aufs, ability to run privileged containers, and a SUPERVISOR_IMAGE to be available locally)
+# * run-supervisor, stop-supervisor - build and start or stop a docker-in-docker balena-supervisor (requires aufs, ability to run privileged containers, and a SUPERVISOR_IMAGE to be available locally)
 #
 # Variables for test/dev targets:
 # * IMAGE: image to build and run (either for run-supervisor or test-gosuper/integration)
@@ -74,10 +74,10 @@ MIXPANEL_TOKEN ?= bananasbananas
 
 # Default architecture and output image
 ARCH ?= amd64
-IMAGE ?= resin/$(ARCH)-supervisor:master
+IMAGE ?= balena/$(ARCH)-supervisor:master
 
 # Default values for run-supervisor
-SUPERVISOR_IMAGE ?= resin/$(ARCH)-supervisor:master
+SUPERVISOR_IMAGE ?= balena/$(ARCH)-supervisor:master
 CONTAINER_NAME ?= supervisor
 CONFIG_FILENAME ?= config.json
 DIND_IMAGE ?= resin/resinos:2.12.5_rev1-intel-nuc

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# resin-supervisor automated build
+# balena-supervisor automated build
 #
 # Required variables:
 # * ARCH
@@ -14,10 +14,10 @@
 # * EXTRA_TAG: when PUSH_IMAGES is true, additional tag to push to the registries
 #
 # Builds the supervisor for the architecture defined by $ARCH.
-# Will produce and push an image tagged as resin/$ARCH-supervisor:$TAG
+# Will produce and push an image tagged as balena/$ARCH-supervisor:$TAG
 #
 # It pulls intermediate images for caching, if available:
-# resin/$ARCH-supervisor-node:$TAG
+# balena/$ARCH-supervisor-node:$TAG
 #
 # In all of these cases it will use "master" if $TAG is not found.
 #
@@ -43,19 +43,19 @@ function tryRemove() {
 }
 
 # This is the supervisor image we will produce
-TARGET_IMAGE=resin/$ARCH-supervisor:$TAG
+TARGET_IMAGE=balena/$ARCH-supervisor:$TAG
 
 # Intermediate images and cache
-NODE_IMAGE=resin/$ARCH-supervisor-node:$TAG
-NODE_BUILD_IMAGE=resin/$ARCH-supervisor-node:$TAG-build
+NODE_IMAGE=balena/$ARCH-supervisor-node:$TAG
+NODE_BUILD_IMAGE=balena/$ARCH-supervisor-node:$TAG-build
 
 TARGET_CACHE=$TARGET_IMAGE
 NODE_CACHE=$NODE_IMAGE
 NODE_BUILD_CACHE=$NODE_BUILD_IMAGE
 
-TARGET_CACHE_MASTER=resin/$ARCH-supervisor:master
-NODE_CACHE_MASTER=resin/$ARCH-supervisor-node:master
-NODE_BUILD_CACHE_MASTER=resin/$ARCH-supervisor-node:master-build
+TARGET_CACHE_MASTER=balena/$ARCH-supervisor:master
+NODE_CACHE_MASTER=balena/$ARCH-supervisor-node:master
+NODE_BUILD_CACHE_MASTER=balena/$ARCH-supervisor-node:master-build
 
 CACHE_FROM=""
 function tryPullForCache() {
@@ -97,8 +97,8 @@ if [ "$PUSH_IMAGES" = "true" ]; then
 	make IMAGE=$TARGET_IMAGE deploy
 
 	if [ -n "$EXTRA_TAG" ]; then
-		docker tag $TARGET_IMAGE resin/$ARCH-supervisor:$EXTRA_TAG
-		make IMAGE=resin/$ARCH-supervisor:$EXTRA_TAG deploy
+		docker tag $TARGET_IMAGE balena/$ARCH-supervisor:$EXTRA_TAG
+		make IMAGE=balena/$ARCH-supervisor:$EXTRA_TAG deploy
 	fi
 fi
 

--- a/automation/deploy-to-balena-cloud.js
+++ b/automation/deploy-to-balena-cloud.js
@@ -1,4 +1,4 @@
-// Deploy a supervisor image as a supervisor_release in the Resin API
+// Deploy a supervisor image as a supervisor_release in the balena API
 //
 // Environment variables:
 // This program deploys for all device types, or only device types where the architecture matches $ARCH, if specified.
@@ -53,15 +53,15 @@ if (!_.isEmpty(apiToken)) {
 
 
 const apiEndpointWithPrefix = url.resolve(apiEndpoint, '/v2/')
-const resinApi = new PineJsClient({
+const balenaApi = new PineJsClient({
 	apiPrefix: apiEndpointWithPrefix,
 	passthrough: requestOpts
 });
 
-resinApi._request(_.extend({
+balenaApi._request(_.extend({
 	url: apiEndpoint + '/config/device-types',
 	method: 'GET'
-}, resinApi.passthrough))
+}, balenaApi.passthrough))
 .then( (deviceTypes) => {
 	// This is a critical step so we better do it serially
 	return Promise.mapSeries(deviceTypes, (deviceType) => {
@@ -75,10 +75,10 @@ resinApi._request(_.extend({
 				arch = 'i386-nlp';
 			}
 			console.log(`Deploying ${tag} for ${deviceType.slug}`);
-			return resinApi.post({
+			return balenaApi.post({
 				resource: 'supervisor_release',
 				body: {
-					image_name: `resin/${arch}-supervisor`,
+					image_name: `balena/${arch}-supervisor`,
 					supervisor_version: tag,
 					device_type: deviceType.slug,
 					is_public: true

--- a/automation/package.json
+++ b/automation/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "resin-supervisor-automation",
+  "name": "balena-supervisor-automation",
   "version": "1.0.0",
-  "description": "Tools to build/deploy resin-supervisor",
-  "main": "deploy-to-resin.js",
+  "description": "Tools to build/deploy balena-supervisor",
+  "main": "deploy-to-balena-cloud.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Resin Inc.",
+  "author": "Balena Ltd.",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.5.0",

--- a/circle.yml
+++ b/circle.yml
@@ -53,11 +53,11 @@ defaults: &defaults
             export TAG=$(echo ${CIRCLE_BRANCH} | sed 's/[^a-z0-9A-Z_.-]/-/g')
             export ARCH=${ARCH}
             bash automation/build.sh
-            if [ "${CIRCLE_BRANCH}" = "master" ] && [ "${DEPLOY_TO_RESIN}" = "true" ]; then
-              echo "Deploying to Resin API (staging)"
-              ARCH=${ARCH} TAG=$VERSION_TAG API_KEY=$STAGING_API_KEY API_ENDPOINT=$STAGING_API_ENDPOINT node automation/deploy-to-resin.js
-              echo "Deploying to Resin API (production)"
-              ARCH=${ARCH} TAG=$VERSION_TAG API_KEY=$PRODUCTION_API_KEY API_ENDPOINT=$PRODUCTION_API_ENDPOINT node automation/deploy-to-resin.js
+            if [ "${CIRCLE_BRANCH}" = "master" ] && [ "${DEPLOY_TO_BALENA}" = "true" ]; then
+              echo "Deploying to balena API (staging)"
+              ARCH=${ARCH} TAG=$VERSION_TAG API_KEY=$STAGING_API_KEY API_ENDPOINT=$STAGING_API_ENDPOINT node automation/deploy-to-balena-cloud.js
+              echo "Deploying to balena API (production)"
+              ARCH=${ARCH} TAG=$VERSION_TAG API_KEY=$PRODUCTION_API_KEY API_ENDPOINT=$PRODUCTION_API_ENDPOINT node automation/deploy-to-balena-cloud.js
             fi
 
 version: 2
@@ -68,48 +68,48 @@ jobs:
       DOCKER_USERNAME: travisciresin
       ARCH: amd64
       PUSH_IMAGES: "true"
-      STAGING_API_ENDPOINT: https://api.resinstaging.io
-      PRODUCTION_API_ENDPOINT: https://api.resin.io
+      STAGING_API_ENDPOINT: https://api.balena-staging.com
+      PRODUCTION_API_ENDPOINT: https://api.balena-cloud.com
   i386:
     <<: *defaults
     environment:
       DOCKER_USERNAME: travisciresin
       ARCH: i386
       PUSH_IMAGES: "true"
-      STAGING_API_ENDPOINT: https://api.resinstaging.io
-      PRODUCTION_API_ENDPOINT: https://api.resin.io
+      STAGING_API_ENDPOINT: https://api.balena-staging.com
+      PRODUCTION_API_ENDPOINT: https://api.balena-cloud.com
   i386-nlp:
     <<: *defaults
     environment:
       DOCKER_USERNAME: travisciresin
       ARCH: i386-nlp
       PUSH_IMAGES: "true"
-      STAGING_API_ENDPOINT: https://api.resinstaging.io
-      PRODUCTION_API_ENDPOINT: https://api.resin.io
+      STAGING_API_ENDPOINT: https://api.balena-staging.com
+      PRODUCTION_API_ENDPOINT: https://api.balena-cloud.com
   armv7hf:
     <<: *defaults
     environment:
       DOCKER_USERNAME: travisciresin
       ARCH: armv7hf
       PUSH_IMAGES: "true"
-      STAGING_API_ENDPOINT: https://api.resinstaging.io
-      PRODUCTION_API_ENDPOINT: https://api.resin.io
+      STAGING_API_ENDPOINT: https://api.balena-staging.com
+      PRODUCTION_API_ENDPOINT: https://api.balena-cloud.com
   aarch64:
     <<: *defaults
     environment:
       DOCKER_USERNAME: travisciresin
       ARCH: aarch64
       PUSH_IMAGES: "true"
-      STAGING_API_ENDPOINT: https://api.resinstaging.io
-      PRODUCTION_API_ENDPOINT: https://api.resin.io
+      STAGING_API_ENDPOINT: https://api.balena-staging.com
+      PRODUCTION_API_ENDPOINT: https://api.balena-cloud.com
   rpi:
     <<: *defaults
     environment:
       DOCKER_USERNAME: travisciresin
       ARCH: rpi
       PUSH_IMAGES: "true"
-      STAGING_API_ENDPOINT: https://api.resinstaging.io
-      PRODUCTION_API_ENDPOINT: https://api.resin.io
+      STAGING_API_ENDPOINT: https://api.balena-staging.com
+      PRODUCTION_API_ENDPOINT: https://api.balena-cloud.com
 
 workflows:
   version: 2


### PR DESCRIPTION
* Images are now pushed to balena/ on dockerhub
* If running a balena/ image, the supervisor still looks for old resin/ images to delete
* Includes a fix for the aarch64 image to build properly, since it was using a deprecated debian repo - this should be temporary until the base image is fixed or updated to stretch