### PR TITLE
fix: When calling the /v1/update endpoint, always trigger a target st…

### DIFF
--- a/src/api-binder.coffee
+++ b/src/api-binder.coffee
@@ -31,7 +31,7 @@ createAPIBinderRouter = (apiBinder) ->
 	router.post '/v1/update', (req, res) ->
 		apiBinder.eventTracker.track('Update notification')
 		if apiBinder.readyForUpdates
-			apiBinder.getAndSetTargetState(req.body.force)
+			apiBinder.getAndSetTargetState(req.body.force, true)
 			.catchReturn()
 		res.sendStatus(204)
 	return router
@@ -363,11 +363,11 @@ module.exports = class APIBinder
 			.timeout(apiTimeout)
 
 	# Get target state from API, set it on @deviceState and trigger a state application
-	getAndSetTargetState: (force) =>
+	getAndSetTargetState: (force, isFromAPI = false) =>
 		Promise.using @_lockGetTarget(), =>
 			@getTargetState()
 			.then (targetState) =>
-				if !_.isEqual(targetState, @lastTarget)
+				if isFromAPI or !_.isEqual(targetState, @lastTarget)
 					@deviceState.setTarget(targetState)
 					.then =>
 						@lastTarget = _.cloneDeep(targetState)


### PR DESCRIPTION
…ate apply

getAndSetTargetState in the APIBinder had a check for whether the target state has changed.
When triggering an update from the API, we want to *always* call triggerApplyTarget, especially
when the update is forced. Otherwise the API endpoint doesn't work for forced updates (and in general,
will rarely trigger an update unless a change in the API's target state has happened)

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>