### PR TITLE
fix: When setting target state, delete old apps from the same source

### DIFF
--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -742,6 +742,8 @@ module.exports = class ApplicationManager extends EventEmitter
 				.tap (appsForDB) =>
 					Promise.map appsForDB, (app) =>
 						@db.upsertModel('app', app, { appId: app.appId }, trx)
+				.then (appsForDB) ->
+					trx('app').where({ source }).whereNotIn('appId', _.map(appsForDB, 'appId')).del()
 			.then =>
 				@proxyvisor.setTargetInTransaction(dependent, trx)
 


### PR DESCRIPTION
In commit 19cd310da367c66cbffdea03245bd987223abc37 this line was deleted,
probably to avoid deleting local mode apps when setting the API target and
viceversa, but we need to delete old apps to avoid problems when moving
the device between apps.

We now filter by source to avoid the problem with local mode too.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>