### PR TITLE
Add a .resinci.yml to disable regular docker and npm builds

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,11 @@
+---
+reviewers: 1
+docker:
+  publish: false
+  builds:
+    - dockerfile: Dockerfile
+      path: .
+      docker_repo: balena/amd64-supervisor
+      publish: false
+npm:
+  run: false


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>