### PR TITLE
V2 service device api improvments

### DIFF
--- a/src/application-manager.d.ts
+++ b/src/application-manager.d.ts
@@ -1,3 +1,4 @@
+import * as Bluebird from 'bluebird';
 import { EventEmitter } from 'events';
 
 import { ServiceAction } from './device-api/common';
@@ -40,7 +41,7 @@ export class ApplicationManager extends EventEmitter {
 	public db: DB;
 	public images: Images;
 
-	public getCurrentApp(appId: number): Promise<Application | null>;
+	public getCurrentApp(appId: number): Bluebird<Application | null>;
 
 	// TODO: This actually returns an object, but we don't need the values just yet
 	public setTargetVolatileForService(serviceId: number, opts: Options): void;
@@ -48,11 +49,11 @@ export class ApplicationManager extends EventEmitter {
 	public executeStepAction(
 		serviceAction: ServiceAction,
 		opts: Options,
-	): Promise<void>;
+	): Bluebird<void>;
 
 	public getStatus(): Promise<DeviceApplicationState>;
 
-	public serviceNameFromId(serviceId: number): Promise<string>;
+	public serviceNameFromId(serviceId: number): Bluebird<string>;
 }
 
 export default ApplicationManager;

--- a/src/compose/images.coffee
+++ b/src/compose/images.coffee
@@ -249,7 +249,7 @@ module.exports = class Images extends EventEmitter
 					supervisorRepos = [ supervisorImageInfo.imageName ]
 					if _.startsWith(supervisorImageInfo.imageName, 'balena/') # We're on a new balena/ARCH-supervisor image
 						supervisorRepos.push(supervisorImageInfo.imageName.replace(/^balena/, 'resin/'))
-					return _.some(supervisorRepos, (repo) -> imageName == img) and tagName != supervisorImageInfo.tagName
+					return _.some(supervisorRepos, (repo) -> imageName == repo) and tagName != supervisorImageInfo.tagName
 				isDangling = (image) ->
 					# Looks like dangling images show up with these weird RepoTags and RepoDigests sometimes
 					(_.isEmpty(image.RepoTags) or _.isEqual(image.RepoTags, [ '<none>:<none>' ])) and

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -4,3 +4,6 @@ export const appNotFoundMessage = `App not found: an app needs to be installed f
 
 export const serviceNotFoundMessage =
 	'Service not found, a container must exist for this endpoint to work';
+
+export const v2ServiceEndpointInputErrorMessage =
+	'This endpoint requires one of imageId or serviceName';


### PR DESCRIPTION
This PR adds a couple of fixes and also adds the `serviceName` parameter to v2 service endpoints, to make it a bit more user friendly.

The documentation will be updated in my other pr: https://github.com/balena-io/balena-supervisor/pull/774