### PR TITLE
Remove node garbage collection flags

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -45,4 +45,4 @@ if [ ! -z "${BALENA_ROOT_CA}" ]; then
 	fi
 fi
 
-exec node --max_old_space_size=50 --optimize_for_size --always_compact /usr/src/app/dist/app.js
+exec node /usr/src/app/dist/app.js


### PR DESCRIPTION
The introduction of these flags correlates with OOM issues on the
supervisor. More investigation is needed into these features
before adding them back into production.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>