### PR TITLE
 api: Ensure Supervisor API returns IP addresses

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -301,7 +301,7 @@ module.exports = class DeviceState extends EventEmitter
 			if changedConfig.connectivityCheckEnabled?
 				network.enableConnectivityCheck(changedConfig.connectivityCheckEnabled)
 		console.log('Starting periodic check for IP addresses')
-		network.startIPAddressUpdate (addresses) =>
+		network.startIPAddressUpdate() (addresses) =>
 			@reportCurrentState(
 				ip_address: addresses.join(' ')
 			)


### PR DESCRIPTION
The move from pure CoffeeScript to TypeScript has brought a
few changes to the way transpiling happens. Previously, through
serendipity, the way `startIPAddressUpdate` was called worked
because of the binding convention pre-transpiling.

However, with the move to TypeScript, this has altered and
the assumption that a lack of parentheses would call the
method before supplying a callback into the returned function
is incorrect. The method must be specifically called first.

Connects-to: #836 
Change-type: patch
Signed-off-by: Heds Simons <heds@balena.io>