### PR TITLE
Fix typo that prevented deleting old resin/ supervisor images

### DIFF
--- a/src/compose/images.coffee
+++ b/src/compose/images.coffee
@@ -248,7 +248,7 @@ module.exports = class Images extends EventEmitter
 				isSupervisorRepoTag = ({ imageName, tagName }) ->
 					supervisorRepos = [ supervisorImageInfo.imageName ]
 					if _.startsWith(supervisorImageInfo.imageName, 'balena/') # We're on a new balena/ARCH-supervisor image
-						supervisorRepos.push(supervisorImageInfo.imageName.replace(/^balena/, 'resin/'))
+						supervisorRepos.push(supervisorImageInfo.imageName.replace(/^balena/, 'resin'))
 					return _.some(supervisorRepos, (repo) -> imageName == repo) and tagName != supervisorImageInfo.tagName
 				isDangling = (image) ->
 					# Looks like dangling images show up with these weird RepoTags and RepoDigests sometimes


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>