### PR TITLE
Fix a race condition that could cause an unnecessary restart

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -584,17 +584,19 @@ module.exports = class DeviceState extends EventEmitter
 				@applyBlocker
 		.then =>
 			@usingInferStepsLock =>
-				Promise.join(
-					@getCurrentForComparison()
-					@getTarget({ initial, intermediate })
-					(currentState, targetState) =>
+				@applications.getExtraStateForComparison()
+				.then (extraState) =>
+					Promise.all([
+						@getCurrentForComparison()
+						@getTarget({ initial, intermediate })
+					])
+					.then ([ currentState, targetState ]) =>
 						@deviceConfig.getRequiredSteps(currentState, targetState)
 						.then (deviceConfigSteps) =>
 							if !_.isEmpty(deviceConfigSteps)
 								return deviceConfigSteps
 							else
-								@applications.getRequiredSteps(currentState, targetState, intermediate)
-				)
+								@applications.getRequiredSteps(currentState, targetState, extraState, intermediate)
 		.then (steps) =>
 			if _.isEmpty(steps)
 				@emitAsync('apply-target-state-end', null)


### PR DESCRIPTION
... of a service immediately after download

Up to now, there was a slim but non-zero chance that an image would be downloaded between the call to `@getTarget` inside deviceState (which gets the target state and creates Service objects using information from available images), and the call to `@images.getAvailable` in ApplicationManager (which is used to determine whether we should keep waiting for a download or start the
service). If this race condition happened, then the ApplicationManager would infer that a service was ready to be started (because the image appears as available), but would have incomplete information about the service because the image wasn't available when the Service object was created. The result would be that the service would be started, and then immediately on the next applyTarget the ApplicationManager would try to kill it and restart it to update it with the complete information from the image.

This patch changes this behavior by ensuring that all of the additional information about the current state, which includes available images,
is gathered *before* building the current and target states that we compare. This means that if the image is downloaded after the call to getAvailable, the Service might be constructed with all the information about the image, but it won't be started until the next pass, because ApplicationManager will treat it as still downloading.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>