### PR TITLE
Fix context bind errors by switching to async/await

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -543,7 +543,8 @@ export class APIBinder {
 			++this.targetStateFetchErrors;
 		}
 
-		return Bluebird.delay(pollInterval).then(this.pollTargetState);
+		await Bluebird.delay(pollInterval);
+		await this.pollTargetState();
 	}
 
 	private async pinDevice({ app, commit }: DevicePinInfo) {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>