### PR TITLE
Fix healthcheck and container restart

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -5,6 +5,7 @@ set -o errexit
 # Start Avahi to allow MDNS lookups
 mkdir -p /var/run/dbus
 rm -f /var/run/avahi-daemon/pid
+rm -f /var/run/dbus/pid
 /etc/init.d/dbus-1 start
 /etc/init.d/avahi-daemon start
 

--- a/src/supervisor-api.ts
+++ b/src/supervisor-api.ts
@@ -95,7 +95,6 @@ export class SupervisorAPI {
 
 		this.api.disable('x-powered-by');
 		this.api.use(expressLogger);
-		this.api.use(authenticate(this.config));
 
 		this.api.get('/v1/healthy', async (_req, res) => {
 			try {
@@ -108,6 +107,8 @@ export class SupervisorAPI {
 				res.sendStatus(500);
 			}
 		});
+
+		this.api.use(authenticate(this.config));
 
 		this.api.get('/ping', (_req, res) => res.send('OK'));
 

--- a/src/supervisor.coffee
+++ b/src/supervisor.coffee
@@ -37,7 +37,18 @@ module.exports = class Supervisor extends EventEmitter
 		# FIXME: rearchitect proxyvisor to avoid this circular dependency
 		# by storing current state and having the APIBinder query and report it / provision devices
 		@deviceState.applications.proxyvisor.bindToAPI(@apiBinder)
-		@api = new SupervisorAPI({ @config, @eventTracker, routers: [ @apiBinder.router, @deviceState.router ], healthchecks: [ @apiBinder.healthcheck, @deviceState.healthcheck ] })
+		@api = new SupervisorAPI({
+			@config,
+			@eventTracker,
+			routers: [
+				@apiBinder.router,
+				@deviceState.router
+			],
+			healthchecks: [
+				@apiBinder.healthcheck.bind(@apiBinder),
+				@deviceState.healthcheck.bind(@deviceState)
+			]
+		})
 
 	init: =>
 		@db.init()


### PR DESCRIPTION
Fixes three issues:
* With the move to supervisor-base 1.4.4, the dbus pid file was left over on restart. This is cleared by the supervisor now on startup
* The authentication middleware for the healthcheck had been moved to be applied before the healthcheck handler, a regression in the typescript conversion, meaning the healthcheck would always return 401
* The healthcheck functions, when converted to typescript, lost their context, so this has been bound.