### PR TITLE
Fix override locking from the dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balena-supervisor",
-  "version": "9.3.1",
+  "version": "9.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8780,9 +8780,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -9164,9 +9164,9 @@
       "dev": true
     },
     "terser": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.11.0.tgz",
-      "integrity": "sha512-5iLMdhEPIq3zFWskpmbzmKwMQixKmTYwY3Ox9pjtSklBLnHiuQ0GKJLhL1HSYtyffHM3/lDIFBnb82m9D7ewwQ==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
+      "integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
       "dev": true,
       "requires": {
         "commander": "~2.17.1",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "rwlock": "^5.0.0",
     "shell-quote": "^1.6.1",
     "strict-event-emitter-types": "^2.0.0",
+    "terser": "^3.14.1",
     "ts-loader": "^5.3.0",
     "typed-error": "^2.0.0",
     "typescript": "^3.2.2",

--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -127,7 +127,7 @@ export class DeviceConfig {
 
 	static validKeys = [
 		'SUPERVISOR_VPN_CONTROL',
-		'OVERRRIDE_LOCK',
+		'OVERRIDE_LOCK',
 		..._.map(DeviceConfig.configKeys, 'envVarName'),
 	];
 

--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -216,9 +216,15 @@ export class DeviceConfig {
 		const db = trx != null ? trx : this.db.models.bind(this.db);
 
 		const formatted = await this.formatConfigKeys(target);
+		// check for legacy keys
+		if (formatted['OVERRIDE_LOCK'] != null) {
+			formatted['SUPERVISOR_OVERRIDE_LOCK'] = formatted['OVERRIDE_LOCK'];
+		}
+
 		const confToUpdate = {
 			targetValues: JSON.stringify(formatted),
 		};
+
 		await db('deviceConfig').update(confToUpdate);
 	}
 
@@ -355,11 +361,6 @@ export class DeviceConfig {
 		const configChanges: Dictionary<string> = {};
 		const humanReadableConfigChanges: Dictionary<string> = {};
 		let reboot = false;
-
-		// If the legacy lock override is used, place it as the new variable
-		if (checkTruthy(target['OVERRIDE_LOCK'])) {
-			target['SUPERVISOR_OVERRIDE_LOCK'] = target['OVERRIDE_LOCK'];
-		}
 
 		_.each(
 			DeviceConfig.configKeys,


### PR DESCRIPTION
The dashboard still sets the legacy var for lock overriding, whose handling was broken due to a typo. This PR fixes the typo and moves the var renaming into the formatting function.