### PR TITLE
Install newer npm in builds to ensure the use of npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,10 @@ RUN apt-get update \
 
 COPY package.json package-lock.json /usr/src/app/
 
-RUN JOBS=MAX npm ci --no-optional --unsafe-perm || JOBS=MAX npm install --no-optional --unsafe-perm
+# install the newer NPM so we can use npm ci
+RUN npm install -g npm@6
+
+RUN JOBS=MAX npm ci --no-optional --unsafe-perm
 
 COPY webpack.config.js fix-jsonstream.js hardcode-migrations.js tsconfig.json /usr/src/app/
 COPY src /usr/src/app/src
@@ -85,10 +88,11 @@ RUN mkdir -p rootfs-overlay && \
 
 COPY package.json package-lock.json /usr/src/app/
 
+# install the newer NPM so we can use npm ci
+RUN npm install -g npm@6
+
 # Install only the production modules that have C extensions
-# First try to install with npm ci, then fallback to npm install
-RUN (JOBS=MAX npm ci --production --no-optional --unsafe-perm || \
- JOBS=MAX npm install --production --no-optional --unsafe-perm) \
+RUN JOBS=MAX npm ci --production --no-optional --unsafe-perm \
 	&& npm dedupe
 
 # Remove various uneeded filetypes in order to reduce space

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ FROM $ARCH-node-build as node-build
 
 WORKDIR /usr/src/app
 
+# install the newer NPM so we can use npm ci
+RUN npm install -g npm@4 && npm install -g npm@5 && npm install -g npm@6
+
 RUN apt-get update \
 	&& apt-get install -y \
 		g++ \
@@ -48,9 +51,6 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/
 
 COPY package.json package-lock.json /usr/src/app/
-
-# install the newer NPM so we can use npm ci
-RUN npm install -g npm@6
 
 RUN JOBS=MAX npm ci --no-optional --unsafe-perm
 
@@ -72,6 +72,9 @@ RUN [ "cross-build-start" ]
 
 WORKDIR /usr/src/app
 
+# install the newer NPM so we can use npm ci
+RUN npm install -g npm@4 && npm install -g npm@5 && npm install -g npm@6
+
 RUN apt-get update \
 	&& apt-get install -y \
 		g++ \
@@ -87,9 +90,6 @@ RUN mkdir -p rootfs-overlay && \
 	ln -s /lib rootfs-overlay/lib64
 
 COPY package.json package-lock.json /usr/src/app/
-
-# install the newer NPM so we can use npm ci
-RUN npm install -g npm@6
 
 # Install only the production modules that have C extensions
 RUN JOBS=MAX npm ci --production --no-optional --unsafe-perm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN mkdir -p rootfs-overlay && \
 COPY package.json package-lock.json /usr/src/app/
 
 # Install only the production modules that have C extensions
-RUN JOBS=MAX npm ci --production --no-optional --unsafe-perm \
+RUN JOBS=MAX npm install --production --no-optional --unsafe-perm \
 	&& npm dedupe
 
 # Remove various uneeded filetypes in order to reduce space

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balena-supervisor",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1537,8 +1537,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -1964,8 +1963,7 @@
     "commander": {
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -3615,9 +3613,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3643,7 +3641,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3667,7 +3665,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3703,7 +3701,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3752,7 +3750,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3772,12 +3770,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -3838,16 +3836,16 @@
           "dev": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3870,7 +3868,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3881,18 +3879,18 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -3909,13 +3907,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3990,12 +3988,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -4025,16 +4023,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true
         },
@@ -4051,7 +4049,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4102,17 +4100,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -4123,12 +4121,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -4137,7 +4135,7 @@
           "dev": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true
         }
@@ -8783,7 +8781,6 @@
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
       "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8792,8 +8789,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -9167,7 +9163,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
       "integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
-      "dev": true,
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1",
@@ -9177,8 +9172,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "rwlock": "^5.0.0",
     "shell-quote": "^1.6.1",
     "strict-event-emitter-types": "^2.0.0",
-    "terser": "^3.14.1",
     "ts-loader": "^5.3.0",
     "typed-error": "^2.0.0",
     "typescript": "^3.2.2",


### PR DESCRIPTION
Instead of pinning dependencies one-by-one as issues come up, we just install the newer npm and always use npm ci in conjunction with the package-lock.