### PR TITLE
fix: Normalize ports from compose file on instantiation

### DIFF
--- a/src/compose/ports.ts
+++ b/src/compose/ports.ts
@@ -140,10 +140,7 @@ export class PortMap {
 	}
 
 	public static fromComposePorts(ports: string[]): PortMap[] {
-		return _(ports)
-			.map(p => new PortMap(p))
-			.sortBy(p => p.ports.internalStart)
-			.value();
+		return PortMap.normalisePortMaps(ports.map(p => new PortMap(p)));
 	}
 
 	private parsePortString(portStr: string): void {

--- a/test/16-ports.spec.coffee
+++ b/test/16-ports.spec.coffee
@@ -252,6 +252,15 @@ describe 'Ports', ->
 
 			expect(portMapsTarget).to.deep.equal(portMapsCurrent)
 
+	describe 'fromComposePorts', ->
+		it 'should normalise compose ports', ->
+			expect(PortMap.fromComposePorts([
+				'80:80',
+				'81:81',
+				'82:82',
+			])).to.deep.equal([
+				new PortMap('80-82')
+			])
 
 	describe 'normalisePortMaps', ->
 


### PR DESCRIPTION
Adjacent ports are always grouped together by docker when reporting the
container state (from an inspect), so adjacent ports defined in the
compose file would not match as they would not have been normalized.

We make sure to always normalize the input port configuration, so that
it will match the docker output (if it should).

We also don't sort in the fromComposePorts function anymore as that is
handled by the normalize function.

Closes: #897
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>