### PR TITLE
Fix whitespace handling in environment variables

### DIFF
--- a/src/lib/conversions.ts
+++ b/src/lib/conversions.ts
@@ -4,7 +4,7 @@ import { EnvVarObject } from './types';
 
 export function envArrayToObject(env: string[]): EnvVarObject {
 	const toPair = (keyVal: string) => {
-		const m = keyVal.match(/^([^=]+)=\s*(.*)\s*$/);
+		const m = keyVal.match(/^([^=]+)=(.*)$/);
 		if (m == null) {
 			console.log(
 				`WARNING: Could not correctly parse env var ${keyVal}. ` +

--- a/src/lib/conversions.ts
+++ b/src/lib/conversions.ts
@@ -4,7 +4,7 @@ import { EnvVarObject } from './types';
 
 export function envArrayToObject(env: string[]): EnvVarObject {
 	const toPair = (keyVal: string) => {
-		const m = keyVal.match(/^([^=]+)=(.*)$/);
+		const m = keyVal.match(/^([^=]+)=([^]*)$/);
 		if (m == null) {
 			console.log(
 				`WARNING: Could not correctly parse env var ${keyVal}. ` +

--- a/test/15-conversions.spec.coffee
+++ b/test/15-conversions.spec.coffee
@@ -43,9 +43,11 @@ describe 'conversions', ->
 			'key2=test\ntest',
 			'key3=test ',
 			'key4= test '
+			'key5=test\r\ntest',
 		])).to.deep.equal({
 			key1: ' test',
 			key2: 'test\ntest',
 			key3: 'test ',
 			key4: ' test ',
+			key5: 'test\r\ntest'
 		})

--- a/test/15-conversions.spec.coffee
+++ b/test/15-conversions.spec.coffee
@@ -37,13 +37,15 @@ describe 'conversions', ->
 			expect(conversion.envArrayToObject([])).to.deep.equal({})
 			expect(conversion.envArrayToObject(1)).to.deep.equal({})
 
-		it 'should ignore leading and trailing whitespace', ->
-			expect(conversion.envArrayToObject([
-				'TEST=\ntest'
-				'TEST2=test\n'
-				'TEST3=\ntest\n'
-			])).to.deep.equal({
-				TEST: 'test'
-				TEST2: 'test'
-				TEST3: 'test'
-			})
+	it 'should correctly handle whitespace', ->
+		expect(conversion.envArrayToObject([
+			'key1= test',
+			'key2=test\ntest',
+			'key3=test ',
+			'key4= test '
+		])).to.deep.equal({
+			key1: ' test',
+			key2: 'test\ntest',
+			key3: 'test ',
+			key4: ' test ',
+		})


### PR DESCRIPTION
We stop stripping whitespace from environment variables, and we also allow newlines in the env var body (to match what the docker daemon supports).

This has been tested with newlines and leading/trailing whitespace from a compose file, and leading/trailing whitespace from the dashboard (which does not allow newlines).