### PR TITLE
Don't treat a non-200 status response on patch as report errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balena-supervisor",
-  "version": "9.6.3",
+  "version": "9.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7487,9 +7487,9 @@
       "dev": true
     },
     "pinejs-client-request": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pinejs-client-request/-/pinejs-client-request-5.1.0.tgz",
-      "integrity": "sha512-usofxkxvlIAYhzesZu7qTYyEISUWPFL9zHY/YItrcPSfN4qWvbY8ixl54kloqKgWS6nYyE72HyFKANzYsQ919w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/pinejs-client-request/-/pinejs-client-request-5.2.0.tgz",
+      "integrity": "sha512-CqmhLgfdjdT6RCduZ+hi5Ne6iVPHF0689IU6RQL7go57kZNcrIXyi6WvKZ6HFmDdZmCtuAv9i/Y0EmMWXhbGjw==",
       "dev": true,
       "requires": {
         "@types/bluebird": "^3.5.23",
@@ -8009,7 +8009,7 @@
     },
     "require-npm4-to-publish": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
       "integrity": "sha1-5Z7D5ikQFT3Fu90MpA20IrLE2ec=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "morgan": "^1.9.1",
     "mz": "^2.7.0",
     "network-checker": "^0.1.1",
-    "pinejs-client-request": "^5.1.0",
+    "pinejs-client-request": "^5.2.0",
     "prettier": "^1.15.3",
     "request": "^2.51.0",
     "resin-lint": "^2.0.1",


### PR DESCRIPTION
Non-200 errors were causing the watchdog to restart the supervisor,
which in some cases could cause a restart loop. Instead we change the
code to only treat communication failures as an error, and report status
code failures directly.

Change-type: patch
Closes: #843
Signed-off-by: Cameron Diver <cameron@balena.io>