### PR TITLE
Better backoff and update lock reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7347,6 +7347,12 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.0.0.tgz",
+      "integrity": "sha512-AddiXFSLLCqj+tCRJ9MrUtHZB4DWojO3tk0NVZ+g5MaMQHF2+p2ktqxuoXyPFLljz/aUK0Nfhd/uGWnhXVXEyA==",
+      "dev": true
+    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -7623,6 +7629,15 @@
             "color-convert": "^1.9.0"
           }
         }
+      }
+    },
+    "pretty-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-4.0.0.tgz",
+      "integrity": "sha512-qG66ahoLCwpLXD09ZPHSCbUWYTqdosB7SMP4OffgTgL2PBKXMuUsrk5Bwg8q4qPkjTXsKBMr+YK3Ltd/6F9s/Q==",
+      "dev": true,
+      "requires": {
+        "parse-ms": "^2.0.0"
       }
     },
     "process": {
@@ -8009,7 +8024,7 @@
     },
     "require-npm4-to-publish": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
       "integrity": "sha1-5Z7D5ikQFT3Fu90MpA20IrLE2ec=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "network-checker": "^0.1.1",
     "pinejs-client-request": "^5.2.0",
     "prettier": "^1.15.3",
+    "pretty-ms": "^4.0.0",
     "request": "^2.51.0",
     "resin-lint": "^2.0.1",
     "resin-register-device": "^3.0.0",

--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -342,6 +342,10 @@ module.exports = class DeviceState extends EventEmitter
 		Promise.using @_inferStepsLock, -> fn()
 
 	setTarget: (target, localSource = false) ->
+		# When we get a new target state, clear any built up apply errors
+		# This means that we can attempt to apply the new state instantly
+		@failedUpdates = 0
+
 		Promise.join(
 			@config.get('apiEndpoint'),
 			validateState(target),

--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -4,6 +4,7 @@ EventEmitter = require 'events'
 fs = Promise.promisifyAll(require('fs'))
 express = require 'express'
 bodyParser = require 'body-parser'
+prettyMs = require 'pretty-ms'
 hostConfig = require './host-config'
 network = require './network'
 execAsync = Promise.promisify(require('child_process').exec)
@@ -584,7 +585,7 @@ module.exports = class DeviceState extends EventEmitter
 			delay = Math.min((2 ** @failedUpdates) * constants.backoffIncrement, @maxPollTime)
 			# If there was an error then schedule another attempt briefly in the future.
 			if err instanceof UpdatesLockedError
-				message = "Updates are locked, retrying in #{delay}ms..."
+				message = "Updates are locked, retrying in #{prettyMs(delay, compact: true)}..."
 				@logger.logSystemMessage(message)
 				console.log(message)
 			else

--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -586,7 +586,7 @@ module.exports = class DeviceState extends EventEmitter
 			# If there was an error then schedule another attempt briefly in the future.
 			if err instanceof UpdatesLockedError
 				message = "Updates are locked, retrying in #{prettyMs(delay, compact: true)}..."
-				@logger.logSystemMessage(message)
+				@logger.logSystemMessage(message, {}, 'updateLocked', false)
 				console.log(message)
 			else
 				console.log('Scheduling another update attempt due to failure: ', delay, err)

--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -584,7 +584,9 @@ module.exports = class DeviceState extends EventEmitter
 			delay = Math.min((2 ** @failedUpdates) * constants.backoffIncrement, @maxPollTime)
 			# If there was an error then schedule another attempt briefly in the future.
 			if err instanceof UpdatesLockedError
-				console.log("Updates are locked, retrying in #{delay}ms...")
+				message = "Updates are locked, retrying in #{delay}ms..."
+				@logger.logSystemMessage(message)
+				console.log(message)
 			else
 				console.log('Scheduling another update attempt due to failure: ', delay, err)
 			@triggerApplyTarget({ force, delay, initial })


### PR DESCRIPTION
When we get a new target state, we reset the apply error counter to 0, meaning we'll try immediately to apply the new state.

We also show better logs when updates are locked.