### PR TITLE
Revert "Upgrade to node 8 for supported architectures"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,27 @@ ARG ARCH=amd64
 
 # The node version here should match the version of the runtime image which is
 # specified in the base-image subdirectory in the project
-FROM balenalib/raspberry-pi-node:8-run as rpi-node-base
-FROM balenalib/armv7hf-node:8-run as armv7hf-node-base
-FROM balenalib/aarch64-node:8-run as aarch64-node-base
+FROM resin/rpi-node:6.13.1-slim as rpi-node-base
+FROM resin/armv7hf-node:6.13.1-slim as armv7hf-node-base
+FROM resin/aarch64-node:6.13.1-slim as aarch64-node-base
 RUN [ "cross-build-start" ]
 RUN sed -i '/security.debian.org jessie/d' /etc/apt/sources.list
 RUN [ "cross-build-end" ]
 
-FROM balenalib/amd64-node:8-run as amd64-node-base
+FROM resin/amd64-node:6.13.1-slim as amd64-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
-FROM balenalib/i386-node:8-run as i386-node-base
+FROM resin/i386-node:6.13.1-slim as i386-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
-FROM resin/i386-node:6.13.1-slim as i386-nlp-node-base
-RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
-	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
-
-# Setup webpack building base images
-# We always do the webpack build on amd64, cause it's way faster
-FROM amd64-node-base as rpi-node-build
-FROM amd64-node-base as amd64-node-build
-FROM amd64-node-base as armv7hf-node-build
-FROM amd64-node-base as aarch64-node-build
-FROM amd64-node-base as i386-node-build
-FROM balenalib/amd64-node:6-build as i386-nlp-node-build
+FROM i386-node-base as i386-nlp-node-base
 
 ##############################################################################
 
-FROM $ARCH-node-build as node-build
+# We always do the webpack build on amd64, cause it's way faster
+FROM amd64-node-base as node-build
 
 WORKDIR /usr/src/app
 
@@ -113,7 +103,7 @@ RUN [ "cross-build-end" ]
 ##############################################################################
 
 # Minimal runtime image
-FROM balena/$ARCH-supervisor-base:v1.4.4
+FROM resin/$ARCH-supervisor-base:v1.3.0
 ARG ARCH
 ARG VERSION=master
 ARG DEFAULT_MIXPANEL_TOKEN=bananasbananas


### PR DESCRIPTION
This reverts commit 338ba4cdd7c6a0a7036e3c9d932622fbe5216436.

This is to unblock the release of the supervisor version, pending the
fix of the introduction of the race condition currently affecting v2
deltas.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>