### PR TITLE
device-config: Add migration for SUPERVISOR_DELTA_APPLY_TIMEOUT

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ import { Transaction } from 'knex';
 import * as _ from 'lodash';
 import { generateUniqueKey } from 'resin-register-device';
 import StrictEventEmitter from 'strict-event-emitter-types';
+import { inspect } from 'util';
 
 import { Either } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
@@ -279,9 +280,10 @@ export class Config extends (EventEmitter as {
 			const decoded = type.decode(value);
 			if (decoded.isLeft()) {
 				throw new TypeError(
-					`Cannot set value for ${key}, as value failed validation: ${
-						decoded.value
-					}`,
+					`Cannot set value for ${key}, as value failed validation: ${inspect(
+						value,
+						{ depth: Infinity },
+					)}`,
 				);
 			}
 			return decoded.value;

--- a/src/migrations/M00003.js
+++ b/src/migrations/M00003.js
@@ -1,0 +1,21 @@
+exports.up = function(knex) {
+	return knex('deviceConfig')
+		.select('targetValues')
+		.then(([target]) => {
+			const targetValues = target.targetValues;
+			const jsonValues = JSON.parse(targetValues);
+
+			if (jsonValues['SUPERVISOR_DELTA_APPLY_TIMEOUT'] === '') {
+				jsonValues['SUPERVISOR_DELTA_APPLY_TIMEOUT'] = '0';
+
+				// Only update the database if we need to
+				return knex('deviceConfig').update({
+					targetValues: JSON.stringify(jsonValues),
+				});
+			}
+		});
+};
+
+exports.down = function(knex, Promise) {
+	return Promise.reject(new Error('Not Implemented'));
+};


### PR DESCRIPTION
The default value for the delta apply timeout was changed from `''` to
`'0'` (note strings as these are database values) - but if the value
existed in the database already, this would fail validation. We add a
migration which will look explcitily for the failing value and switch it
to the new default.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>