### PR TITLE
feature: Add `BALENA_API_URL` environment variable

### DIFF
--- a/src/compose/types/service.ts
+++ b/src/compose/types/service.ts
@@ -188,6 +188,7 @@ export interface DeviceMetadata {
 	version: string;
 	deviceType: string;
 	deviceApiKey: string;
+	apiEndpoint: string;
 	listenPort: number;
 	apiSecret: string;
 	supervisorApiHost: string;

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -357,6 +357,7 @@ export function addFeaturesFromLabels(
 
 	if (checkTruthy(service.config.labels['io.balena.features.balena-api'])) {
 		setEnvVariables('API_KEY', options.deviceApiKey);
+		setEnvVariables('API_URL', options.apiEndpoint);
 	}
 
 	if (checkTruthy(service.config.labels['io.balena.features.supervisor-api'])) {

--- a/src/config/functions.ts
+++ b/src/config/functions.ts
@@ -76,6 +76,7 @@ export const fnSchema = {
 			'listenPort',
 			'name',
 			'apiSecret',
+			'apiEndpoint',
 			'deviceApiKey',
 			'version',
 			'deviceType',

--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -218,6 +218,7 @@ export const schemaTypes = {
 			name: t.string,
 			apiSecret: t.union([t.string, NullOrUndefined]),
 			deviceApiKey: t.string,
+			apiEndpoint: t.string,
 			version: t.string,
 			deviceType: t.string,
 			osVersion: t.union([t.string, NullOrUndefined]),


### PR DESCRIPTION
When using the label `io.balena.features.balena-api` the supervisor will inject 2 environment
variables into the container:
- BALENA_API_KEY
- BALENA_API_URL

This allows the container to access the currently associated API using the KEY.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>
Connects-to: #847