### PR TITLE
state-engine: Add rate limited steps to device-config

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -42,7 +42,7 @@ export function enableCheck(enable: boolean) {
 
 async function vpnStatusInotifyCallback(): Promise<void> {
 	try {
-		await fs.lstat(constants.vpnStatusPath);
+		await fs.lstat(`${constants.vpnStatusPath}/active`);
 		isConnectivityCheckPaused = true;
 	} catch {
 		isConnectivityCheckPaused = false;


### PR DESCRIPTION
In the case of an airgapped supervisor, with a target state that
requests the vpn be enabled, the supervisor will constantly loop on
trying to set the vpn to on. Unfortunately the vpn requires an internet
connection to be configured, so it will never be turned on.

We add the concept of no-ops to the device-config state change steps,
and don't end the state engine transition while these are present
(similar to how image pulls are implemented).

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>