### PR TITLE
Only modprobe ip6_tables if it's necessary

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -52,6 +52,8 @@ if [ ! -d /lib/modules ]; then
 	ln -s /mnt/root/lib/modules /lib/modules
 fi
 # Now load the ip6_tables kernel module, so we can do filtering on ipv6 addresses
-modprobe ip6_tables
+if [ -z "$(cat /proc/config.gz | gunzip | grep CONFIG_IP6_NF_IPTABLES=y || true)" ]; then
+  modprobe ip6_tables
+fi
 
 exec node /usr/src/app/dist/app.js


### PR DESCRIPTION
If the kernel was built with support for ip6tables, there's no need to load the module. This is the case when running
balenaOS in a container in Mac OS, which also can't do modprobes easily.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>