### PR TITLE
Add libusb support

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -338,6 +338,10 @@ export function addFeaturesFromLabels(
 		service.config.volumes.push('/lib/firmware:/lib/firmware');
 	}
 
+	if (checkTruthy(service.config.labels['io.balena.features.usb'])) {
+		service.config.volumes.push('/dev/bus/usb:/dev/bus/usb');
+	}
+
 	if (checkTruthy(service.config.labels['io.balena.features.balena-socket'])) {
 		service.config.volumes.push(
 			`${constants.dockerSocket}:${constants.dockerSocket}`,


### PR DESCRIPTION
Add `io.balena.features.usb` label to allow using libusb inside the containers.

From [balena forums](https://forums.balena.io/t/libusb0-py-cannot-open-a-directory/62).