### PR TITLE
Additions to the V2 supervisor api

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1102,3 +1102,27 @@ Response:
 	"serviceName": "main"
 }
 ```
+
+### V2 Device Information
+
+#### Device name
+
+Added in supervisor version v9.11.0
+
+Get the last returned device name from the balena API. Note that this differs from the
+`BALENA_DEVICE_NAME_AT_INIT` environment variable provided to containers, as this will
+not change throughout the runtime of the container, but the endpoint will always return
+the latest known device name.
+
+From an application container:
+```
+$ curl "$BALENA_SUPERVISOR_ADDRESS/v2/device/name?apikey=$BALENA_SUPERVISOR_API_KEY"
+```
+
+Response:
+```json
+{
+	"status": "success",
+	"deviceName": "holy-wildflower"
+}
+```

--- a/docs/API.md
+++ b/docs/API.md
@@ -1126,3 +1126,29 @@ Response:
 	"deviceName": "holy-wildflower"
 }
 ```
+
+#### Device tags
+
+Added in supervisor version v9.11.0
+
+Retrieve any device tags from the balena API. Note that this endpoint will not work when
+the device does not have an available connection to the balena API.
+
+From an application container:
+```
+$ curl "$BALENA_SUPERVISOR_ADDRESS/v2/device/tags?apikey=$BALENA_SUPERVISOR_API_KEY"
+```
+
+Response:
+```json
+{
+	"status": "success",
+	"tags": [
+		{
+			"id": 188303,
+			"name": "DeviceLocation",
+			"value": "warehouse #3"
+		}
+	]
+}
+```

--- a/src/application-manager.d.ts
+++ b/src/application-manager.d.ts
@@ -12,6 +12,7 @@ import DB from './db';
 
 import { Service } from './compose/service';
 import Config from './config';
+import { APIBinder } from './api-binder';
 
 declare interface Options {
 	force?: boolean;
@@ -37,6 +38,7 @@ export class ApplicationManager extends EventEmitter {
 	public logger: Logger;
 	public deviceState: any;
 	public eventTracker: EventTracker;
+	public apiBinder: APIBinder;
 
 	public services: ServiceManager;
 	public config: Config;

--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -451,4 +451,19 @@ export function createV2Api(router: Router, applications: ApplicationManager) {
 			});
 		}
 	});
+
+	router.get('/v2/device/tags', async (_req, res) => {
+		try {
+			const tags = await applications.apiBinder.fetchDeviceTags();
+			return res.json({
+				status: 'success',
+				tags,
+			});
+		} catch (e) {
+			res.status(503).json({
+				status: 'failed',
+				message: messageFromError(e),
+			});
+		}
+	});
 }

--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -436,4 +436,19 @@ export function createV2Api(router: Router, applications: ApplicationManager) {
 			release: currentRelease,
 		});
 	});
+
+	router.get('/v2/device/name', async (_req, res) => {
+		try {
+			const deviceName = await applications.config.get('name');
+			res.json({
+				status: 'success',
+				deviceName,
+			});
+		} catch (e) {
+			res.status(503).json({
+				status: 'failed',
+				message: messageFromError(e),
+			});
+		}
+	});
 }

--- a/src/supervisor.coffee
+++ b/src/supervisor.coffee
@@ -37,6 +37,9 @@ module.exports = class Supervisor extends EventEmitter
 		# FIXME: rearchitect proxyvisor to avoid this circular dependency
 		# by storing current state and having the APIBinder query and report it / provision devices
 		@deviceState.applications.proxyvisor.bindToAPI(@apiBinder)
+		# We could also do without the below dependency, but it's part of a much larger refactor
+		@deviceState.applications.apiBinder = @apiBinder
+
 		@api = new SupervisorAPI({
 			@config,
 			@eventTracker,


### PR DESCRIPTION
Adds the `v2/device/name` and `v2/device/tags` endpoints, with associated documentation.

@shaunmulligan the name is cached, but the device tags require an active connection to the api. Is this ok, or would you like me to build some caching into the device tags? More importantly, should this always be available?