### PR TITLE
Fix network alias creation and comparison

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -9,8 +9,6 @@ do ->
 			return lookup(name, { verbatim: true }, opts)
 		return lookup(name, Object.assign({ verbatim: true }, opts), cb)
 
-require('log-timestamp')
-
 Supervisor = require './supervisor'
 
 supervisor = new Supervisor()

--- a/src/compose/service-manager.ts
+++ b/src/compose/service-manager.ts
@@ -20,6 +20,7 @@ import {
 import * as LogTypes from '../lib/log-types';
 import { checkInt, isValidDeviceName } from '../lib/validation';
 import { Service } from './service';
+import { serviceNetworksToDockerNetworks } from './utils';
 
 interface ServiceConstructOpts {
 	docker: Docker;
@@ -266,7 +267,9 @@ export class ServiceManager extends (EventEmitter as {
 			}
 
 			const conf = service.toDockerContainer({ deviceName });
-			const nets = service.extraNetworksToJoin();
+			const nets = serviceNetworksToDockerNetworks(
+				service.extraNetworksToJoin(),
+			);
 
 			this.logger.logSystemEvent(LogTypes.installService, { service });
 			this.reportNewStatus(mockContainerId, service, 'Installing');
@@ -275,7 +278,7 @@ export class ServiceManager extends (EventEmitter as {
 			service.containerId = container.id;
 
 			await Promise.all(
-				_.map(nets, (endpointConfig, name) =>
+				_.map((nets || {}).EndpointsConfig, (endpointConfig, name) =>
 					this.docker.getNetwork(name).connect({
 						Container: container.id,
 						EndpointConfig: endpointConfig,

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -802,8 +802,8 @@ export class Service {
 		appId: number,
 		serviceName: string,
 	): { [envVarName: string]: string } {
-		let defaultEnv: { [envVarName: string]: string } = {};
-		for (let namespace of ['BALENA', 'RESIN']) {
+		const defaultEnv: { [envVarName: string]: string } = {};
+		for (const namespace of ['BALENA', 'RESIN']) {
 			_.assign(
 				defaultEnv,
 				_.mapKeys(

--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -348,7 +348,7 @@ export function addFeaturesFromLabels(
 			}`;
 		}
 		// We keep balena.sock for backwards compatibility
-		if (constants.dockerSocket != '/var/run/balena.sock') {
+		if (constants.dockerSocket !== '/var/run/balena.sock') {
 			service.config.volumes.push(
 				`${constants.dockerSocket}:/var/run/balena.sock`,
 			);

--- a/test/04-service.spec.coffee
+++ b/test/04-service.spec.coffee
@@ -311,7 +311,9 @@ describe 'compose/service', ->
 							IPAMConfig: {
 								IPv4Address: '1.2.3.4'
 							},
-							Aliases: []
+							Aliases: [
+								'test'
+							]
 						}
 					}
 				})


### PR DESCRIPTION
Before this change, service name resolution would only occur in the
default network. This was because we were not explicitly adding aliases
of the service names to the aliases fields.

We also fix the comparison, which would do funny things based on
container IDs, which was correct but unnecessary.

Also fix a couple of lint errors.

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_i3ln)