### PR TITLE
fix: Correct use of $expand to avoid an exception when updating from …

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -172,7 +172,8 @@ module.exports = class DeviceState extends EventEmitter
 						commit: app.commit
 						status: 'success'
 					$expand:
-						contains__image: [ 'image' ]
+						contains__image:
+							$expand: 'image'
 			)
 			.then (releasesFromAPI) =>
 				if releasesFromAPI.length == 0


### PR DESCRIPTION
…a legacy OS

The last update of pinejs-client to pinejs-client-request made the way we were
using $expand on the migration break. This switches to the correct way of doing it now.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>