### PR TITLE
automation: Add missing pine-client-request library

### DIFF
--- a/automation/package.json
+++ b/automation/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "lodash": "^4.17.4",
-    "pinejs-client": "^4.0.0"
+    "pinejs-client": "^4.0.0",
+    "pinejs-client-request": "^5.2.0"
   }
 }


### PR DESCRIPTION
Required by `deploy-to-balena-cloud.js`, but not installed normally

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>