### PR TITLE
fix: Await reporting the initial config before continuing APIBinder init

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -704,7 +704,7 @@ export class APIBinder {
 		} catch (err) {
 			console.error('Error reporting initial configuration, will retry', err);
 			await Bluebird.delay(retryDelay);
-			this.reportInitialConfig(apiEndpoint, retryDelay);
+			await this.reportInitialConfig(apiEndpoint, retryDelay);
 		}
 	}
 


### PR DESCRIPTION

This avoid a race condition, in which config.txt can be cleared if a target state is fetched before the
initial values have been created as config vars.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>