### PR TITLE
Ensure the supervisor0 network uses a subnet less likely to cause conflicts

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -53,6 +53,8 @@ const constants = {
 	// Use this failure multiplied by 2**Number of failures to increase
 	// the backoff on subsequent failures
 	backoffIncrement: 500,
+	supervisorNetworkSubnet: '10.114.104.0/25',
+	supervisorNetworkGateway: '10.114.104.1',
 };
 
 if (process.env.DOCKER_HOST == null) {


### PR DESCRIPTION

We put the supervisor0 network in the 10.114.104.0/25 subnet to avoid issues when the device
is in a network using the 172.17.* network.

We also ensure we recreate this network if it was created in the incorrect subnet (i.e. if we're updating
from an old supervisor that didn't do this), for which we have to kill any containers using this network.

Closes #731

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>

<img src="https://frontapp.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_i74b)