### PR TITLE
avahi: Remove default service definitions

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -2,7 +2,9 @@
 
 set -o errexit
 
-# Start Avahi to allow MDNS lookups
+# Start Avahi to allow MDNS lookups and remove
+# any pre-defined services
+rm -f /etc/avahi/services/*
 mkdir -p /var/run/dbus
 rm -f /var/run/avahi-daemon/pid
 rm -f /var/run/dbus/pid


### PR DESCRIPTION
Removes default 'example' service definitions that
are included by Avahi 0.7+. These conflict with
our balenaOS advertised services, causing potential
issues.

Connects-to: #957
Change-type: patch
Signed-off-by: Heds Simons <heds@balena.io>