### PR TITLE
Don't attempt to report any state during local mode

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -521,6 +521,9 @@ export class APIBinder {
 
 	private reportCurrentState(): null {
 		(async () => {
+			if ((await this.config.get('localMode')) === true) {
+				return;
+			}
 			this.reportPending = true;
 			try {
 				const currentDeviceState = await this.deviceState.getStatus();


### PR DESCRIPTION
Even though this would never have attempted to report the state to the
api during local mode, it leaves behind artifacts which would cause the
state to be sometimes reported when exiting local mode. This would cause
the api to reject the update unecessarily.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>