### PR TITLE
compose: Remove unique expose entries after adding all entries

### DIFF
--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -279,12 +279,12 @@ export class Service {
 			{},
 		);
 		expose = expose.concat(_.keys(imageExposedPorts));
-		expose = _.uniq(expose);
 		// Also add any exposed ports which are implied from the portMaps
 		const exposedFromPortMappings = _.flatMap(portMaps, port =>
 			port.toExposedPortArray(),
 		);
 		expose = expose.concat(exposedFromPortMappings);
+		expose = _.uniq(expose);
 		delete config.expose;
 
 		let devices: DockerDevice[] = [];


### PR DESCRIPTION
Prior to this change, we would `_.uniq` the expose value before adding
values from the port mappings. This could cause ports to get added
twice, which would cause the supervisor to think that there is a
configuration mismatch.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>