### PR TITLE
Fix supervisor tests for node v10.12.0 and above

### DIFF
--- a/src/logging/balena-backend.ts
+++ b/src/logging/balena-backend.ts
@@ -141,7 +141,7 @@ export class BalenaLogBackend extends LogBackend {
 		this.timeout = setTimeout(() => {
 			if (this.gzip != null) {
 				this.stream.pipe(this.gzip);
-				this.flush();
+				setImmediate(this.flush);
 			}
 		}, RESPONSE_GRACE_PERIOD);
 	}, COOLDOWN_PERIOD);


### PR DESCRIPTION
Changes in the node engine related to streams would cause the gzip
streams flush function to be called at the wrong times. The sinon fake
timers were also interacting with this.

We use setImmediate to call the flush function, and remove sinon timers
for the logging tests.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>