### PR TITLE
Re-apply "Upgrade to node 8 for supported architectures" with delta fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,39 @@ ARG ARCH=amd64
 
 # The node version here should match the version of the runtime image which is
 # specified in the base-image subdirectory in the project
-FROM balenalib/rpi-node:6.16.0 as rpi-node-base
-FROM balenalib/armv7hf-node:6.16.0 as armv7hf-node-base
-FROM balenalib/aarch64-node:6.16.0 as aarch64-node-base
+FROM balenalib/raspberry-pi-node:8-run as rpi-node-base
+FROM balenalib/armv7hf-node:8-run as armv7hf-node-base
+FROM balenalib/aarch64-node:8-run as aarch64-node-base
 RUN [ "cross-build-start" ]
 RUN sed -i '/security.debian.org jessie/d' /etc/apt/sources.list
 RUN [ "cross-build-end" ]
 
-FROM balenalib/amd64-node:6.16.0 as amd64-node-base
+FROM balenalib/amd64-node:8-run as amd64-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
-FROM balenalib/i386-node:6.16.0 as i386-node-base
+FROM balenalib/i386-node:8-run as i386-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
-FROM i386-node-base as i386-nlp-node-base
+FROM resin/i386-node:6.13.1-slim as i386-nlp-node-base
+RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
+	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end \
+	# TODO: Move this to a balenalib image so this isn't necessary
+	&& sed -i '/jessie-updates/{s/^/#/}' /etc/apt/sources.list
+
+# Setup webpack building base images
+# We always do the webpack build on amd64, cause it's way faster
+FROM amd64-node-base as rpi-node-build
+FROM amd64-node-base as amd64-node-build
+FROM amd64-node-base as armv7hf-node-build
+FROM amd64-node-base as aarch64-node-build
+FROM amd64-node-base as i386-node-build
+FROM balenalib/amd64-node:6-build as i386-nlp-node-build
 
 ##############################################################################
 
-# We always do the webpack build on amd64, cause it's way faster
-FROM amd64-node-base as node-build
+FROM $ARCH-node-build as node-build
 
 WORKDIR /usr/src/app
 
@@ -103,7 +115,7 @@ RUN [ "cross-build-end" ]
 ##############################################################################
 
 # Minimal runtime image
-FROM resin/$ARCH-supervisor-base:v1.3.0
+FROM balena/$ARCH-supervisor-base:v1.4.5
 ARG ARCH
 ARG VERSION=master
 ARG DEFAULT_MIXPANEL_TOKEN=bananasbananas

--- a/package-lock.json
+++ b/package-lock.json
@@ -2520,9 +2520,9 @@
       }
     },
     "docker-delta": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/docker-delta/-/docker-delta-2.2.4.tgz",
-      "integrity": "sha512-rb2d2S+2pibHXA2ODZvGMaCupAgGXQTpoSBXCZlRLA9EGdy6HatowGha5IWJ70h65+6O3CC9xNaaGEzfNJko3w==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/docker-delta/-/docker-delta-2.2.9.tgz",
+      "integrity": "sha512-2avbIg8rpg8uRqYAux4df5HAJChbx+W3LQMMeafOY7m3bt1wlaJVPDIKbh0mCuquicp5JKnFNiGU8+V558J/Ng==",
       "dev": true,
       "requires": {
         "bluebird": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "copy-webpack-plugin": "^4.6.0",
     "dbus-native": "^0.2.5",
     "deep-object-diff": "^1.1.0",
-    "docker-delta": "^2.2.4",
+    "docker-delta": "^2.2.9",
     "docker-progress": "^3.0.3",
     "docker-toolbelt": "^3.3.7",
     "duration-js": "^4.0.0",

--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -45,6 +45,7 @@ fetchAction = (service) ->
 		action: 'fetch'
 		image: imageForService(service)
 		serviceId: service.serviceId
+		serviceName: service.serviceName
 	}
 
 # TODO: implement additional v2 endpoints
@@ -138,6 +139,7 @@ module.exports = class ApplicationManager extends EventEmitter
 								# and it's relevant mostly for the legacy GET /v1/device endpoint
 								# that assumes a single-container app
 								@reportCurrentState(update_downloaded: true)
+						, step.serviceName
 				)
 			removeImage: (step) =>
 				@images.remove(step.image)

--- a/src/compose/images.ts
+++ b/src/compose/images.ts
@@ -89,6 +89,7 @@ export class Images extends (EventEmitter as {
 		image: Image,
 		opts: FetchOptions,
 		onFinish = _.noop,
+		serviceName: string,
 	): Promise<null> {
 		if (this.imageFetchFailures[image.name] != null) {
 			// If we are retrying a pull within the backoff time of the last failure,
@@ -148,7 +149,7 @@ export class Images extends (EventEmitter as {
 			try {
 				let id;
 				if (opts.delta && (opts as DeltaFetchOptions).deltaSource != null) {
-					id = await this.fetchDelta(image, opts, onProgress);
+					id = await this.fetchDelta(image, opts, onProgress, serviceName);
 				} else {
 					id = await this.fetchImage(image, opts, onProgress);
 				}
@@ -598,6 +599,7 @@ export class Images extends (EventEmitter as {
 		image: Image,
 		opts: FetchOptions,
 		onProgress: (evt: FetchProgressEvent) => void,
+		serviceName: string,
 	): Promise<string> {
 		this.logger.logSystemEvent(LogTypes.downloadImageDelta, { image });
 
@@ -609,6 +611,7 @@ export class Images extends (EventEmitter as {
 			image.name,
 			deltaOpts,
 			onProgress,
+			serviceName,
 		);
 
 		if (!Images.hasDigest(image.name)) {

--- a/src/lib/docker-utils.ts
+++ b/src/lib/docker-utils.ts
@@ -55,6 +55,7 @@ export class DockerUtils extends DockerToolbelt {
 		imgDest: string,
 		deltaOpts: DeltaFetchOptions,
 		onProgress: ProgressCallback,
+		serviceName: string,
 	): Promise<string> {
 		const deltaSourceId =
 			deltaOpts.deltaSourceId != null
@@ -64,7 +65,7 @@ export class DockerUtils extends DockerToolbelt {
 		const timeout = deltaOpts.deltaApplyTimeout;
 
 		const log = (str: string) =>
-			console.log(`delta(${deltaOpts.deltaSource}): ${str}`);
+			console.log(`delta([${serviceName}] ${deltaOpts.deltaSource}): ${str}`);
 
 		if (!_.includes([2, 3], deltaOpts.deltaVersion)) {
 			log(

--- a/test/14-application-manager.spec.coffee
+++ b/test/14-application-manager.spec.coffee
@@ -226,6 +226,7 @@ describe 'ApplicationManager', ->
 					image: @applications.imageForService(target.local.apps[0].services[1])
 					serviceId: 24
 					appId: 1234
+					serviceName: 'anotherService'
 				}])
 		)
 
@@ -264,7 +265,8 @@ describe 'ApplicationManager', ->
 					action: 'fetch'
 					image: @applications.imageForService(target.local.apps[0].services[0])
 					serviceId: 23
-					appId: 1234
+					appId: 1234,
+					serviceName: 'aservice'
 				}, { action: 'noop', appId: 1234 }])
 		)
 


### PR DESCRIPTION
We upgrade docker-delta and re-apply the commit which updated to node 8 for supported architectures.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>