### PR TITLE
Fix regression where node_modules stayed in resulting image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,9 +86,9 @@ COPY package.json package-lock.json /usr/src/app/
 
 # Install only the production modules that have C extensions
 RUN (if [ $ARCH = "i386-nlp" ]; then \
- JOBS=MAX npm install --no-optional --unsafe-perm; \
+ JOBS=MAX npm install --no-optional --unsafe-perm --production; \
 else \
- JOBS=MAX npm ci --no-optional --unsafe-perm; \
+ JOBS=MAX npm ci --no-optional --unsafe-perm --production; \
 fi) && npm dedupe
 
 # Remove various uneeded filetypes in order to reduce space


### PR DESCRIPTION
Reduces the image size by about 200mb.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>