### PR TITLE
Update and improve debug and development tools

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -72,4 +72,4 @@ HEALTHCHECK --interval=5m --start-period=1m --timeout=30s --retries=3 \
 
 RUN [ "cross-build-end" ]
 
-CMD DEBUG=1 ./entry.sh
+CMD DEBUG=1 ./entry.sh || while true; do echo 'Supervisor runtime exited - waiting for changes'; sleep 100; done;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6303,9 +6303,9 @@
       }
     },
     "livepush": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/livepush/-/livepush-1.2.1.tgz",
-      "integrity": "sha512-6BD16S8EtyVsNqI5PHI/MRiho1LhkYR9Gjy2AXWm3S/cssV0TlVJpyhz1nMWxCDGjbJAWjcYwbvSAeBua7RUhA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/livepush/-/livepush-1.2.4.tgz",
+      "integrity": "sha512-AKGlJ+QuelyDoOV0cbGfeskLf2RaYIcHnKogfircvTl9//BNDrGVhrcO6bN3kcVaJnYKnvXwXOtGOyrsl6wI9A==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "json-mask": "^0.3.8",
     "knex": "~0.15.2",
     "lint-staged": "^8.1.0",
-    "livepush": "^1.2.1",
+    "livepush": "^1.2.4",
     "lockfile": "^1.0.1",
     "lodash": "^4.17.5",
     "log-timestamp": "^0.1.2",


### PR DESCRIPTION
Add a debounce to the livepush invocations, execute on start and also
add a wait on the supervisor CMD line for those rare occassions where
the supervisor enters a restart loop.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>