### PR TITLE
Report device state in local mode

### DIFF
--- a/test/api-binder.ts
+++ b/test/api-binder.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { APIBinder, APIBinderConstructOpts } from '../src/api-binder';
+import { DeviceApplicationState } from '../src/types/state';
+
+describe('APIBinder', () => {
+	let apiBinder: APIBinder;
+
+	before(() => {
+		apiBinder = new APIBinder({} as APIBinderConstructOpts);
+	});
+
+	describe('stripDeviceStateInLocalMode', () => {
+		const sampleState = {
+			local: {
+				ip_address: '192.168.1.42 192.168.1.99',
+				api_port: 48484,
+				api_secret:
+					'20ffbd6e15aba827dca6381912d6aeb6c3a7a7c7206d4dfadf0d2f0a9e1136',
+				os_version: 'balenaOS 2.32.0+rev4',
+				os_variant: 'dev',
+				supervisor_version: '9.16.3',
+				provisioning_progress: null,
+				provisioning_state: '',
+				status: 'Idle',
+				logs_channel: null,
+				apps: {},
+				is_on__commit: 'whatever',
+			},
+			dependent: { apps: {} },
+		} as DeviceApplicationState;
+
+		it('should strip applications data', () => {
+			const result = apiBinder.stripDeviceStateInLocalMode(
+				sampleState,
+			) as Dictionary<any>;
+			expect(result).to.not.have.property('dependent');
+
+			const local = result['local'];
+			expect(local).to.not.have.property('apps');
+			expect(local).to.not.have.property('is_on__commit');
+			expect(local).to.not.have.property('logs_channel');
+		});
+	});
+});


### PR DESCRIPTION
In local mode, we now update device status on the backend,
but omit applications info in our updates.

Closes: #959
Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>