### PR TITLE
Ensure that every architecture uses npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM balenalib/i386-node:10-run as i386-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
-FROM balenalib/i386-nlp-node:6-run as i386-nlp-node-base
+FROM balenalib/i386-nlp-node:6-jessie as i386-nlp-node-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,5 @@
 ARG ARCH=amd64
+ARG NPM_VERSION=6.9.0
 
 # The node version here should match the version of the runtime image which is
 # specified in the base-image subdirectory in the project
@@ -36,17 +37,21 @@ RUN [ "cross-build-start" ]
 WORKDIR /usr/src/app
 
 RUN apt-get update && apt-get install ca-certificates \
-	iptables libnss-mdns nodejs rsync git python make wget g++ \
+	iptables libnss-mdns nodejs rsync git python make curl g++ \
 	kmod vim
 
 COPY package*.json ./
 
-# i386-nlp doesn't have an npm version which supports ci
-RUN if [ $ARCH = "i386-nlp" ]; then \
- JOBS=MAX npm install --no-optional --unsafe-perm; \
-else \
- JOBS=MAX npm ci --no-optional --unsafe-perm; \
-fi
+
+# We first ensure that every architecture has an npm version
+# which can do an npm ci, then we perform the ci using this
+# temporary version
+RUN curl -LOJ https://www.npmjs.com/install.sh && \
+	# This is required to avoid a bug in uid-number
+	# https://github.com/npm/uid-number/issues/7
+	npm config set unsafe-perm true && \
+	npm_install="${NPM_VERSION}" npm_config_prefix=/tmp sh ./install.sh && \
+	JOBS=MAX /tmp/bin/npm ci --no-optional --unsafe-perm
 
 COPY src src/
 COPY typings typings/

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -18,11 +18,9 @@ FROM balenalib/i386-node:10-run as i386-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
 	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
-FROM resin/i386-node:6.13.1-slim as i386-nlp-base
+FROM balenalib/i386-nlp-node:6-jessie as i386-nlp-base
 RUN echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-start && chmod +x /usr/bin/cross-build-start \
-	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end \
-	# TODO: Move this to a balenalib image so this isn't necessary
-	&& sed -i '/jessie-updates/{s/^/#/}' /etc/apt/sources.list
+	&& echo '#!/bin/sh\nexit 0' > /usr/bin/cross-build-end && chmod +x /usr/bin/cross-build-end
 
 # A little hack to make this work with the makefile
 FROM $ARCH-base AS node-build


### PR DESCRIPTION
We do this by using the standalone installer pinned at v6.9.0. We use the standalone installer because npm itself fails to upgrade on the i386-nlp build (npm v3). The standalone installer is installed in /tmp, and then to avoid mysterious CI errors, we use the original npm to run the tests.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>