### PR TITLE
Change to https for cloning resinos-in-container submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tools/dind/resinos-in-container"]
 	path = tools/dind/resinos-in-container
-	url = git@github.com:resin-os/resinos-in-container.git
+	url = https://github.com/balena-os/resinos-in-container.git


### PR DESCRIPTION
May require a `git submodule sync` to update existing local config

Change-type: patch

Fixes #1016 