### PR TITLE
Fix tests run removing .only

### DIFF
--- a/test/local-mode.ts
+++ b/test/local-mode.ts
@@ -279,7 +279,7 @@ describe('LocalModeManager', () => {
 				removeStubs.forEach(s => expect(s.remove.callCount).to.be.equal(2));
 			});
 
-			it.only('skips cleanup in case of data corruption', async () => {
+			it('skips cleanup in case of data corruption', async () => {
 				const removeStubs = stubRemoveMethods(false);
 
 				await db.models('engineSnapshot').insert({


### PR DESCRIPTION
The issue was introduced with one of the recent changes (#1012) related to local mode cleanup.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>