### PR TITLE
fix: When reporting initial config, avoid creating a "VPN enabled" un…

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -708,7 +708,7 @@ export class APIBinder {
 				varValue = 'true';
 			}
 
-			if (targetConfig[key] == null && value !== defaultConfig[key]) {
+			if (targetConfig[key] == null && varValue !== defaultConfig[key]) {
 				const envVar = {
 					value: varValue,
 					device: deviceId,


### PR DESCRIPTION
…necessary override

Since we were comparing the VPN's value before adding the explicit "true", there were cases
were the VPN is off, and therefore "value" didn't match the default, so the supervisor would
create a device specific SUPERVISOR_VPN_CONTROL = true, which is unnecessary and causes issues if users don't expect this and move the device to an app that has VPN disabled. The correct behavior
is to compare "varValue" and only create a device config var if this value differs from the default.

(This was the behavior before the TS conversion in 01ed7bb103b4df8fb0679cf858220db42d4a0b92 )

Closes #1024 

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablo@balena.io>