### PR TITLE
Add mocha tests linter

### DIFF
--- a/automation/lint-mocha-tests.js
+++ b/automation/lint-mocha-tests.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+// This script checks if files in test directory don't contain describe.only or it.only statements
+// to ensure that an accidental commit does not prevent all the tests to be run.
+
+const fs = require('fs');
+const path = require('path');
+
+const testsDir = './test';
+const srcFileExtensions = ['.ts', '.coffee', '.js'];
+
+const checkPattern = /((describe)|(it))\.only/;
+
+const checkDirRecursively = (dirPath, func) =>
+	fs.readdirSync(dirPath, {withFileTypes: true}).forEach((file) => {
+		const filePath = path.join(dirPath, file.name);
+		if (file.isDirectory()) {
+			checkDirRecursively(filePath, func);
+			return;
+		}
+		for (let ext of srcFileExtensions) {
+			if (file.name.endsWith(ext)) {
+				const content = fs.readFileSync(filePath, {encoding: 'utf8'});
+				func(filePath, content);
+				break;
+			}
+		}
+	});
+
+let errorsFound = false;
+
+checkDirRecursively(testsDir, (fileName, content) => {
+	const lines = content.split('\n');
+	for (let ln = 0; ln < lines.length; ln++) {
+		const res = checkPattern.exec(lines[ln]);
+		if (res) {
+			errorsFound = true;
+			console.error(`File ${fileName}, line ${ln}: found ${res[0]}`);
+		}
+	}
+});
+
+if (errorsFound) {
+	process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "coverage": "istanbul report text && istanbul report html",
     "test:fast": "npm run test:build && mocha",
     "test:debug": "npm run test:build && mocha --inspect-brk",
-    "precommit": "lint-staged",
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{src,test,typings}/**/*.ts\"",
     "typescript:test-build": "tsc --project tsconfig.json",
     "typescript:release": "tsc --project tsconfig.release.json && cp -r build/src/* build && rm -rf build/src",
@@ -118,5 +117,10 @@
     "webpack": "^4.25.0",
     "webpack-cli": "^3.1.2",
     "winston": "^3.2.1"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged && automation/lint-mocha-tests.js"
+    }
   }
 }


### PR DESCRIPTION
A simple script that detects presence of .only statements in tests.
The idea is to avoid committing them, so that all the tests are run with `npm test`.

The change also removes deprecation warning generated by husky (asking to migrate to a new configuration style).

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>