### PR TITLE
Don't attempt to cleanup any target state referenced volumes

### DIFF
--- a/src/application-manager.d.ts
+++ b/src/application-manager.d.ts
@@ -11,11 +11,14 @@ import ServiceManager from './compose/service-manager';
 import DB from './db';
 
 import { APIBinder } from './api-binder';
-import { Service } from './compose/service';
 import Config from './config';
 
 import NetworkManager from './compose/network-manager';
 import VolumeManager from './compose/volume-manager';
+
+import Network from './compose/network';
+import Service from './compose/service';
+import Volume from './compose/volume';
 
 declare interface Options {
 	force?: boolean;
@@ -65,6 +68,14 @@ export class ApplicationManager extends EventEmitter {
 	// FIXME: Type this properly as it's some mutant state between
 	// the state endpoint and the ApplicationManager internals
 	public getStatus(): Promise<Dictionay<any>>;
+	// The return type is incompleted
+	public getTargetApps(): Promise<
+		Dictionary<{
+			services: Dictionary<Service>;
+			volumes: Dictionary<Volume>;
+			networks: Dictionary<Network>;
+		}>
+	>;
 
 	public serviceNameFromId(serviceId: number): Bluebird<string>;
 }

--- a/src/compose/volume-manager.ts
+++ b/src/compose/volume-manager.ts
@@ -129,7 +129,9 @@ export class VolumeManager {
 		return volume;
 	}
 
-	public async removeOrphanedVolumes(): Promise<void> {
+	public async removeOrphanedVolumes(
+		referencedVolumes: string[],
+	): Promise<void> {
 		// Iterate through every container, and track the
 		// references to a volume
 		// Note that we're not just interested in containers
@@ -151,7 +153,13 @@ export class VolumeManager {
 			.value();
 		const volumeNames = _.map(dockerVolumes.Volumes, 'Name');
 
-		const volumesToRemove = _.difference(volumeNames, containerVolumes);
+		const volumesToRemove = _.difference(
+			volumeNames,
+			containerVolumes,
+			// Don't remove any volume which is still referenced
+			// in the target state
+			referencedVolumes,
+		);
 		await Promise.all(
 			volumesToRemove.map(v => this.docker.getVolume(v).remove()),
 		);


### PR DESCRIPTION
The code before this change could potentially remove a volume which
should not be removed if a container was deleted before the call that
references said volume.

To avoid this, we additionally filter the list of volumes to cleanup by
any that are referenced in the target state. This means that cleanup
will never remove it, as long as it's still supposed to be there,
regardless of if a container references it or not.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>