### PR TITLE
Prevent supervisor from deleting itself

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,7 @@ const constants = {
 	rootMountPoint,
 	databasePath:
 		checkString(process.env.DATABASE_PATH) || '/data/database.sqlite',
+	containerId: checkString(process.env.SUPERVISOR_CONTAINER_ID) || undefined,
 	dockerSocket: process.env.DOCKER_SOCKET || '/var/run/docker.sock',
 	supervisorImage:
 		checkString(process.env.SUPERVISOR_IMAGE) || 'resin/rpi-supervisor',

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -62,3 +62,9 @@ export class ConfigurationValidationError extends TypedError {
 }
 
 export class ImageAuthenticationError extends TypedError {}
+
+/**
+ * An error thrown if our own container cannot be inspected.
+ * See LocalModeManager for a usage example.
+ */
+export class SupervisorContainerNotFoundError extends TypedError {}

--- a/src/local-mode.ts
+++ b/src/local-mode.ts
@@ -155,8 +155,8 @@ export class LocalModeManager {
 		return new EngineSnapshot(
 			[inspectInfo.Id],
 			[inspectInfo.Image],
-			inspectInfo.Mounts.filter(m => m.Name !== undefined).map(m => m.Name!),
-			_.values(inspectInfo.NetworkSettings.Networks).map(ns => ns.NetworkID),
+			inspectInfo.Mounts.filter(m => m.Name != null).map(m => m.Name!),
+			_.map(inspectInfo.NetworkSettings.Networks, n => n.NetworkID),
 		);
 	}
 

--- a/src/local-mode.ts
+++ b/src/local-mode.ts
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 import Config from './config';
 import Database from './db';
 import * as constants from './lib/constants';
+import { SupervisorContainerNotFoundError } from './lib/errors';
 import log from './lib/supervisor-console';
 import { Logger } from './logger';
 
@@ -176,7 +177,7 @@ export class LocalModeManager {
 				);
 				return this.collectContainerResources(fallback);
 			}
-			throw e;
+			throw new SupervisorContainerNotFoundError(e);
 		}
 	}
 

--- a/src/local-mode.ts
+++ b/src/local-mode.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 
 import Config from './config';
 import Database from './db';
+import * as constants from './lib/constants';
 import log from './lib/supervisor-console';
 import { Logger } from './logger';
 
@@ -56,6 +57,9 @@ export class EngineSnapshotRecord {
 	) {}
 }
 
+/** Container name used to inspect own resources when container ID cannot be resolved. */
+const SUPERVISOR_CONTAINER_NAME_FALLBACK = 'resin_supervisor';
+
 /**
  * This class handles any special cases necessary for switching
  * modes in localMode.
@@ -70,6 +74,7 @@ export class LocalModeManager {
 		public docker: Docker,
 		public logger: Logger,
 		public db: Database,
+		private containerId: string | undefined = constants.containerId,
 	) {}
 
 	// Indicates that switch from or to the local mode is not complete.
@@ -140,6 +145,39 @@ export class LocalModeManager {
 			new EngineSnapshot(containers, images, volumes, networks),
 			new Date(),
 		);
+	}
+
+	private async collectContainerResources(
+		nameOrId: string,
+	): Promise<EngineSnapshot> {
+		const inspectInfo = await this.docker.getContainer(nameOrId).inspect();
+		return new EngineSnapshot(
+			[inspectInfo.Id],
+			[inspectInfo.Image],
+			inspectInfo.Mounts.filter(m => m.Name !== undefined).map(m => m.Name!),
+			_.values(inspectInfo.NetworkSettings.Networks).map(ns => ns.NetworkID),
+		);
+	}
+
+	// Determine what engine objects are linked to our own container.
+	private async collectOwnResources(): Promise<EngineSnapshot> {
+		try {
+			return this.collectContainerResources(
+				this.containerId || SUPERVISOR_CONTAINER_NAME_FALLBACK,
+			);
+		} catch (e) {
+			if (this.containerId !== undefined) {
+				// Inspect operation fails (container ID is out of sync?).
+				const fallback = SUPERVISOR_CONTAINER_NAME_FALLBACK;
+				log.warn(
+					'Supervisor container resources cannot be obtained by container ID. ' +
+						`Using '${fallback}' name instead.`,
+					e.message,
+				);
+				return this.collectContainerResources(fallback);
+			}
+			throw e;
+		}
 	}
 
 	private async cleanEngineSnapshots() {
@@ -248,11 +286,16 @@ export class LocalModeManager {
 				return;
 			}
 
+			const supervisorResources = await this.collectOwnResources();
+			log.debug(`${supervisorResources} are linked to current supervisor`);
+
 			log.debug(
 				`Leaving local mode and cleaning up objects since ${previousRecord.timestamp.toISOString()}`,
 			);
 			await this.removeLocalModeArtifacts(
-				currentRecord.snapshot.diff(previousRecord.snapshot),
+				currentRecord.snapshot
+					.diff(previousRecord.snapshot)
+					.diff(supervisorResources),
 			);
 			await this.cleanEngineSnapshots();
 		} catch (e) {


### PR DESCRIPTION
With recent changes to local mode behavior, supervisor removes all engine objects
that were not present before entering local mode.
With this change, supervisor also detects its own resources and does not delete them
if it was updated during local mode operations.

Related to https://github.com/balena-os/meta-balena/pull/1590 and https://github.com/balena-os/balena-engine/issues/173

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>