### PR TITLE
api: Perform network checks if device is unmanaged

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -307,7 +307,6 @@ module.exports = class DeviceState extends EventEmitter
 				@triggerApplyTarget({ initial: true })
 
 	initNetworkChecks: ({ apiEndpoint, connectivityCheckEnabled, unmanaged }) =>
-		return if unmanaged
 		network.startConnectivityCheck apiEndpoint, connectivityCheckEnabled, (connected) =>
 			@connected = connected
 		@config.on 'change', (changedConfig) ->


### PR DESCRIPTION
Without these checks the API GET /v1/device doesn't return a
value for `ip_address`.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>