### PR TITLE
modification to unpacking volume backup

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -434,7 +434,7 @@ module.exports = class DeviceState extends EventEmitter
 			.then ->
 				mkdirp(backupPath)
 			.then ->
-				execAsync("tar -xzf backup.tgz -C #{backupPath} .", cwd: path.join(constants.rootMountPoint, 'mnt/data'))
+				execAsync("tar -xzf backup.tgz -C #{backupPath}", cwd: path.join(constants.rootMountPoint, 'mnt/data'))
 			.then ->
 				fs.readdirAsync(backupPath)
 			.then (dirContents) =>


### PR DESCRIPTION
Due to changes in migrator volume backups cannot be unpacked any more with 
tar -xzf backup.tgz -C #{backupPath} .
Leaving away the '.' works for old and new backups