### PR TITLE
Only consider certain array fields without order

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -499,3 +499,60 @@ export function normalizeLabels(labels: {
 	);
 	return _.assign({}, otherLabels, legacyLabels, balenaLabels);
 }
+
+function compareArrayField(
+	arr1: unknown[],
+	arr2: unknown[],
+	ordered: boolean,
+): boolean {
+	if (!ordered) {
+		arr1 = _.sortBy(arr1);
+		arr2 = _.sortBy(arr2);
+	}
+	return _.isEqual(arr1, arr2);
+}
+
+export function compareArrayFields<T extends Dictionary<unknown>>(
+	obj1: T,
+	obj2: T,
+	nonOrderedFields: Array<keyof T>,
+	orderedFields: Array<keyof T>,
+): { equal: false; difference: string[] };
+export function compareArrayFields<T extends Dictionary<unknown>>(
+	obj1: T,
+	obj2: T,
+	nonOrderedFields: Array<keyof T>,
+	orderedFields: Array<keyof T>,
+): { equal: true };
+export function compareArrayFields<T extends Dictionary<unknown>>(
+	obj1: T,
+	obj2: T,
+	nonOrderedFields: Array<keyof T>,
+	orderedFields: Array<keyof T>,
+): { equal: boolean; difference?: string[] } {
+	let equal = true;
+	const difference: string[] = [];
+	for (const { fields, ordered } of [
+		{ fields: nonOrderedFields, ordered: false },
+		{ fields: orderedFields, ordered: true },
+	]) {
+		for (const field of fields) {
+			if (
+				!compareArrayField(
+					obj1[field] as unknown[],
+					obj2[field] as unknown[],
+					ordered,
+				)
+			) {
+				equal = false;
+				difference.push(field as string);
+			}
+		}
+	}
+
+	if (equal) {
+		return { equal };
+	} else {
+		return { equal, difference };
+	}
+}

--- a/test/04-service.spec.coffee
+++ b/test/04-service.spec.coffee
@@ -1,4 +1,4 @@
-{ expect } = require './lib/chai-config'
+{ assert, expect } = require './lib/chai-config'
 
 _ = require 'lodash'
 
@@ -209,6 +209,101 @@ describe 'compose/service', ->
 		}, { appName: 'test' })
 
 		expect(service.config).to.have.property('expose').that.deep.equals(['80/tcp', '100/tcp'])
+
+	describe 'Ordered array parameters', ->
+		it 'Should correctly compare ordered array parameters', ->
+			svc1 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				dns: [
+					'8.8.8.8',
+					'1.1.1.1',
+				]
+			}, { appName: 'test' })
+			svc2 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				dns: [
+					'8.8.8.8',
+					'1.1.1.1',
+				]
+			}, { appName: 'test' })
+			assert(svc1.isEqualConfig(svc2))
+
+			svc2 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				dns: [
+					'1.1.1.1',
+					'8.8.8.8',
+				]
+			}, { appName: 'test' })
+			assert(!svc1.isEqualConfig(svc2))
+
+		it 'should correctly compare non-ordered array parameters', ->
+			svc1 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				volumes: [
+					'abcdef',
+					'ghijk',
+				]
+			}, { appName: 'test' })
+			svc2 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				volumes: [
+					'abcdef',
+					'ghijk',
+				]
+			}, { appName: 'test' })
+			assert(svc1.isEqualConfig(svc2))
+
+			svc2 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				volumes: [
+					'ghijk',
+					'abcdef',
+				]
+			}, { appName: 'test' })
+			assert(svc1.isEqualConfig(svc2))
+
+		it 'should correctly compare both ordered and non-ordered array parameters', ->
+			svc1 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				volumes: [
+					'abcdef',
+					'ghijk',
+				],
+				dns: [
+					'8.8.8.8',
+					'1.1.1.1',
+				]
+			}, { appName: 'test' })
+			svc2 = Service.fromComposeObject({
+				appId: 1,
+				serviceId: 1,
+				serviceName: 'test',
+				volumes: [
+					'ghijk',
+					'abcdef',
+				],
+				dns: [
+					'8.8.8.8',
+					'1.1.1.1',
+				]
+			}, { appName: 'test' })
+			assert(svc1.isEqualConfig(svc2))
+
 
 	describe 'parseMemoryNumber()', ->
 		makeComposeServiceWithLimit = (memLimit) ->


### PR DESCRIPTION
Various fields returned from the docker daemon don't retain order (for
example the volumes field). We now only select certain array values to
compare taking order into account.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>