### PR TITLE
device-state: correctly call volume creation on backup restore step

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -452,7 +452,7 @@ module.exports = class DeviceState extends EventEmitter
 									volume.remove()
 							.catch(NotFoundError, _.noop)
 							.then =>
-								@applications.volumes.createFromPath({ appId, name: volumeName, config: volumes[volumeName] }, path.join(backupPath, volumeName))
+								@applications.volumes.createFromPath({ appId, name: volumeName }, volumes[volumeName], path.join(backupPath, volumeName))
 						else
 							throw new Error("Invalid backup: #{volumeName} is present in backup but not in target state")
 			.then ->


### PR DESCRIPTION
The `createFromPath` method takes 3 parameters, while in a previous version it was only 2, before the refactor in commit 23e564389daaa29feb231d1b091e07df82a7a300 (supervisor v9.18.4) The backup restoration call has not been updated and thus calls that function the old (wrong) way, resulting in failed restore, and volume management errors on a device that attempted a restore.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>