### PR TITLE
Correctly handle partial IPAM configurations for networks

### DIFF
--- a/src/compose/network.ts
+++ b/src/compose/network.ts
@@ -103,14 +103,10 @@ export class Network {
 
 		Network.validateComposeConfig(network);
 
-		const ipam =
-			network.ipam != null
-				? network.ipam
-				: {
-						driver: 'default',
-						config: [],
-						options: {},
-				  };
+		const ipam: Partial<ComposeNetworkConfig['ipam']> = network.ipam || {};
+		if (ipam.driver == null) {
+			ipam.driver = 'default';
+		}
 		if (ipam.config == null) {
 			ipam.config = [];
 		}
@@ -119,7 +115,7 @@ export class Network {
 		}
 		net.config = {
 			driver: network.driver || 'bridge',
-			ipam,
+			ipam: ipam as ComposeNetworkConfig['ipam'],
 			enableIPv6: network.enable_ipv6 || false,
 			internal: network.internal || false,
 			labels: network.labels || {},

--- a/test/18-compose-network.coffee
+++ b/test/18-compose-network.coffee
@@ -37,6 +37,36 @@ describe 'compose/network', ->
 				options: {}
 			})
 
+		it 'should handle an incomplete ipam configuration', ->
+			network = Network.fromComposeObject('test', 123, {
+				ipam: {
+					config: [
+						{
+							subnet: '172.25.0.0/25',
+							gateway: '172.25.0.1'
+						}
+					]
+				}
+			}, { logger: null, docker: null })
+
+			expect(network.config).to.deep.equal({
+				driver: 'bridge',
+				enableIPv6: false,
+				internal: false,
+				labels: {}
+				options: {}
+				ipam: {
+					driver: 'default',
+					options: {},
+					config: [
+						{
+							subnet: '172.25.0.0/25',
+							gateway: '172.25.0.1'
+						}
+					]
+				}
+			})
+
 	describe 'internal config -> docker config', ->
 
 		it 'should convert an internal representation to a docker representation', ->


### PR DESCRIPTION
Currently, the driver can be missing from the IPAM configuration if it's not provided in the docker-compose. This would cause the supervisor to think the network needed to be recreated, and would stop all associated services. This patch fixes the parsing of incomplete configuration to make sure all fields are set.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>