### PR TITLE
Fix purge action, after v10 volume rework

### DIFF
--- a/src/logging/balena-backend.ts
+++ b/src/logging/balena-backend.ts
@@ -203,8 +203,12 @@ export class BalenaLogBackend extends LogBackend {
 		}
 
 		if (this.writable) {
-			this.writable = this.stream.write(JSON.stringify(message) + '\n');
-			this.flush();
+			try {
+				this.writable = this.stream.write(JSON.stringify(message) + '\n');
+				this.flush();
+			} catch (e) {
+				log.error('Failed to write to logging stream, dropping message.', e);
+			}
 		} else {
 			this.dropCount += 1;
 		}


### PR DESCRIPTION
We explicitly remove the volumes are part of the endpoint workflow, as the application manager engine will not remove them if they are still part of an active application.