### PR TITLE
Add a cache around the database application target state

### DIFF
--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -17,7 +17,7 @@ updateLock = require './lib/update-lock'
 { ContractViolationError, ContractValidationError, NotFoundError } = require './lib/errors'
 { pathExistsOnHost } = require './lib/fs-utils'
 
-{ ApplicationTargetStateWrapper } = require './target-state'
+{ TargetStateAccessor } = require './target-state'
 
 { ServiceManager } = require './compose/service-manager'
 { Service } = require './compose/service'
@@ -82,7 +82,7 @@ module.exports = class ApplicationManager extends EventEmitter
 		@_targetVolatilePerImageId = {}
 		@_containerStarted = {}
 
-		@targetStateWrapper = new ApplicationTargetStateWrapper(this, @config, @db)
+		@targetStateWrapper = new TargetStateAccessor(this, @config, @db)
 
 		@config.on 'change', (changedConfig) =>
 			if changedConfig.appUpdatePollInterval

--- a/src/target-state.ts
+++ b/src/target-state.ts
@@ -20,7 +20,7 @@ export type DatabaseApps = DatabaseApp[];
  * line. This can very quickly cause serious memory problems
  * and database connection timeouts.
  */
-export class ApplicationTargetStateWrapper {
+export class TargetStateAccessor {
 	private targetState?: DatabaseApps;
 
 	public constructor(
@@ -77,4 +77,4 @@ export class ApplicationTargetStateWrapper {
 	}
 }
 
-export default ApplicationTargetStateWrapper;
+export default TargetStateAccessor;


### PR DESCRIPTION
This should stop OOM errors when the application containers are logging excessively in local mode.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>