### PR TITLE
event-tracker: Use std mixpanel types

### DIFF
--- a/test/09-event-tracker.spec.ts
+++ b/test/09-event-tracker.spec.ts
@@ -1,5 +1,6 @@
+import { Mixpanel } from 'mixpanel';
 import * as mixpanel from 'mixpanel';
-import { stub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { expect } from './lib/chai-config';
 
@@ -9,12 +10,16 @@ import supervisorVersion = require('../src/lib/supervisor-version');
 describe('EventTracker', () => {
 	let eventTrackerOffline: EventTracker;
 	let eventTracker: EventTracker;
+	let initStub: SinonStub;
 
 	before(() => {
-		stub(mixpanel, 'init').callsFake(token => ({
-			token,
-			track: stub().returns(undefined),
-		}));
+		initStub = stub(mixpanel, 'init').callsFake(
+			token =>
+				(({
+					token,
+					track: stub().returns(undefined),
+				} as unknown) as Mixpanel),
+		);
 
 		eventTrackerOffline = new EventTracker();
 		eventTracker = new EventTracker();
@@ -23,7 +28,7 @@ describe('EventTracker', () => {
 
 	after(() => {
 		(EventTracker.prototype as any).logEvent.restore();
-		return mixpanel.init.restore();
+		return initStub.restore();
 	});
 
 	it('initializes in unmanaged mode', () => {

--- a/typings/mixpanel.d.ts
+++ b/typings/mixpanel.d.ts
@@ -1,1 +1,0 @@
-declare module 'mixpanel';


### PR DESCRIPTION
Custom type definitions are removed for mixpanel module since they are embedded
into their npm package.

This change also adds an extra check for events tracking logic in a hope we can
investigate some weird events we see in the analytics system.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>