### PR TITLE
Add regression test for app manager init

### DIFF
--- a/test/14-application-manager.spec.coffee
+++ b/test/14-application-manager.spec.coffee
@@ -142,6 +142,7 @@ describe 'ApplicationManager', ->
 			})
 		stub(@applications.docker, 'getNetworkGateway').returns(Promise.resolve('172.17.0.1'))
 		stub(@applications.docker, 'listContainers').returns(Promise.resolve([]))
+		stub(@applications.docker, 'listImages').returns(Promise.resolve([]))
 		stub(Service, 'extendEnvVars').callsFake (env) ->
 			env['ADDITIONAL_ENV_VAR'] = 'foo'
 			return env
@@ -194,6 +195,9 @@ describe 'ApplicationManager', ->
 		@applications.docker.getNetworkGateway.restore()
 		@applications.docker.listContainers.restore()
 		Service.extendEnvVars.restore()
+
+	it 'should init', ->
+		@applications.init()
 
 	it 'infers a start step when all that changes is a running state', ->
 		Promise.join(


### PR DESCRIPTION
If we had it earlier, it would have prevented #1148.
When init is called, withImagesFromDockerAndDB in images.ts is called as well.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>