### PR TITLE
volumes: Allow the use of the 'driver' setting in volumes

### DIFF
--- a/src/application-manager.coffee
+++ b/src/application-manager.coffee
@@ -666,11 +666,12 @@ module.exports = class ApplicationManager extends EventEmitter
 
 				Promise.map(JSON.parse(app.services), (service) => @createTargetService(service, configOpts))
 				.then (services) =>
-					# If a named volume is defined in a service, we add it app-wide so that we can track it and purge it
+					# If a named volume is defined in a service but NOT in the volumes of the compose file, we add it app-wide so that we can track it and purge it
+					# !! DEPRECATED, WILL BE REMOVED IN NEXT MAJOR RELEASE !!
 					for s in services
 						serviceNamedVolumes = s.getNamedVolumes()
 						for name in serviceNamedVolumes
-							volumes[name] = @createTargetVolume(name, app.appId, { labels: {} })
+							volumes[name] ?= @createTargetVolume(name, app.appId, { labels: {} })
 					outApp = {
 						appId: app.appId
 						name: app.name

--- a/test/20-compose-volume.ts
+++ b/test/20-compose-volume.ts
@@ -44,9 +44,13 @@ describe('Compose volumes', () => {
 				.to.have.property('config')
 				.that.has.property('driverOpts')
 				.that.deep.equals({});
+			expect(volume)
+				.to.have.property('config')
+				.that.has.property('driver')
+				.that.equals('local');
 		});
 
-		it('should correctly parse compose volumes', () => {
+		it('should correctly parse compose volumes without an explicit driver', () => {
 			const volume = Volume.fromComposeObject(
 				'one_volume',
 				1032480,
@@ -80,6 +84,51 @@ describe('Compose volumes', () => {
 				.that.deep.equals({
 					opt1: 'test',
 				});
+			expect(volume)
+				.to.have.property('config')
+				.that.has.property('driver')
+				.that.equals('local');
+		});
+
+		it('should correctly parse compose volumes with an explicit driver', () => {
+			const volume = Volume.fromComposeObject(
+				'one_volume',
+				1032480,
+				{
+					driver: 'other',
+					driver_opts: {
+						opt1: 'test',
+					},
+					labels: {
+						'my-label': 'test-label',
+					},
+				},
+				opts,
+			);
+
+			expect(volume)
+				.to.have.property('appId')
+				.that.equals(1032480);
+			expect(volume)
+				.to.have.property('name')
+				.that.equals('one_volume');
+			expect(volume)
+				.to.have.property('config')
+				.that.has.property('labels')
+				.that.deep.equals({
+					'io.balena.supervised': 'true',
+					'my-label': 'test-label',
+				});
+			expect(volume)
+				.to.have.property('config')
+				.that.has.property('driverOpts')
+				.that.deep.equals({
+					opt1: 'test',
+				});
+			expect(volume)
+				.to.have.property('config')
+				.that.has.property('driver')
+				.that.equals('other');
 		});
 	});
 


### PR DESCRIPTION
A compose file can now contain a volume which uses a different driver
from the default one; local.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>