### PR TITLE
Add steps info to applyState error message

### DIFF
--- a/src/device-state.coffee
+++ b/src/device-state.coffee
@@ -440,6 +440,9 @@ module.exports = class DeviceState extends EventEmitter
 			.delay(nextDelay)
 			.then =>
 				@applyTarget({ force, initial, intermediate, skipLock, nextDelay, retryCount })
+			.catch (err) =>
+				detailedError = new Error('Failed to apply state transition steps. ' + err.message + ' Steps:' + JSON.stringify(_.map(steps, 'action')))
+				@applyError(detailedError, { force, initial, intermediate })
 		.catch (err) =>
 			@applyError(err, { force, initial, intermediate })
 


### PR DESCRIPTION
This helps to debug/diagnose problems with state application faster.

Inspired by a recent debug session. Example:
```
[error]   Scheduling another update attempt in 16000ms due to failure:  Error: Failed to apply state transition steps. (HTTP code 404) no such container - sandbox f6110534fcb6eb967385962938996b369bdcf5d828ee08a4b19a9fbd5b3ee89a not found  Steps:["updateMetadata"]
```

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>