### PR TITLE
Increase the minimum backoff delay and use poll inteval as the max

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -549,7 +549,7 @@ export class APIBinder {
 				}
 
 				await this.report();
-				await this.reportCurrentState();
+				this.reportCurrentState();
 			} catch (e) {
 				this.eventTracker.track('Device state report failure', { error: e });
 				// We use the poll interval as the upper limit of
@@ -562,7 +562,7 @@ export class APIBinder {
 
 				++this.stateReportErrors;
 				await Bluebird.delay(delay);
-				await this.reportCurrentState();
+				this.reportCurrentState();
 			}
 		})();
 		return null;


### PR DESCRIPTION
This change will start the minimum backoff from 15s (up from 500ms) and
will use the appUpdatePollInterval configuration variable as the max.