### PR TITLE
Make balena-sync optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
     "@types/tmp": "^0.1.0",
-    "balena-sync": "^10.0.0",
     "blinking": "~0.0.2",
     "bluebird": "^3.5.3",
     "body-parser": "^1.12.0",
@@ -124,6 +123,9 @@
     "webpack-cli": "^3.1.2",
     "winston": "^3.2.1",
     "yargs": "^15.1.0"
+  },
+  "optionalDependencies": {
+    "balena-sync": "^10.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Drivelist won't build with node12, and it won't build at all with osx.
We make balena-sync optional so that everything but sync.js will work
fine on these platforms.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>