### PR TITLE
Feat/support filtering logs by container

### DIFF
--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -471,8 +471,16 @@ export function createV2Api(router: Router, applications: ApplicationManager) {
 		const count = checkInt(req.body.count, { positive: true }) || undefined;
 		const unit = req.body.unit;
 		const format = req.body.format || 'short';
+		const containerId = req.body.containerId;
 
-		const journald = spawnJournalctl({ all, follow, count, unit, format });
+		const journald = spawnJournalctl({
+			all,
+			follow,
+			count,
+			unit,
+			format,
+			containerId,
+		});
 		res.status(200);
 		journald.stdout.pipe(res);
 		res.on('close', () => {

--- a/src/lib/journald.ts
+++ b/src/lib/journald.ts
@@ -8,6 +8,7 @@ export function spawnJournalctl(opts: {
 	follow: boolean;
 	count?: number;
 	unit?: string;
+	containerId?: string;
 	format: string;
 }): ChildProcess {
 	const args = [
@@ -24,6 +25,10 @@ export function spawnJournalctl(opts: {
 	if (opts.unit != null) {
 		args.push('-u');
 		args.push(opts.unit);
+	}
+	if (opts.containerId != null) {
+		args.push('-t');
+		args.push(opts.containerId);
 	}
 	if (opts.count != null) {
 		args.push('-n');

--- a/test/26-journald.spec.ts
+++ b/test/26-journald.spec.ts
@@ -1,0 +1,57 @@
+import { SinonStub, stub } from 'sinon';
+import constants = require('../src/lib/constants');
+import { spawnJournalctl } from '../src/lib/journald';
+import { expect } from './lib/chai-config';
+
+describe('journald', () => {
+	let spawn: SinonStub;
+
+	beforeEach(done => {
+		spawn = stub(require('child_process'), 'spawn');
+		done();
+	});
+
+	afterEach(done => {
+		spawn.restore();
+		done();
+	});
+
+	it('spawnJournalctl calls spawn child process with expected args', () => {
+		spawnJournalctl({
+			all: true,
+			follow: true,
+			count: 10,
+			unit: 'nginx.service',
+			containerId: 'abc123',
+			format: 'json-pretty',
+		});
+
+		const expectedCommand = `chroot`;
+		const expectedCoreArgs = [`${constants.rootMountPoint}`, 'journalctl'];
+		const expectedOptionalArgs = [
+			'-a',
+			'--follow',
+			'-u',
+			'nginx.service',
+			'-t',
+			'abc123',
+			'-n',
+			'10',
+			'-o',
+			'json-pretty',
+		];
+
+		const actualCommand = spawn.firstCall.args[0];
+		const actualCoreArgs = spawn.firstCall.args[1].slice(0, 2);
+		const actualOptionalArgs = spawn.firstCall.args[1].slice(2);
+
+		expect(spawn.calledOnce).to.be.true;
+
+		expect(actualCommand).deep.equal(expectedCommand);
+		expect(actualCoreArgs).deep.equal(expectedCoreArgs);
+
+		expectedOptionalArgs.forEach(arg => {
+			expect(actualOptionalArgs).to.include(arg);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1203

Also adds a unit test for journald module, to ensure `child_process.spawn` is called with expected args.