### PR TITLE
Don't wrap UpdatesLockedErrors with a detailed error

### DIFF
--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -774,17 +774,16 @@ export class DeviceState extends (EventEmitter as new () => DeviceStateEventEmit
 					retryCount,
 				});
 			} catch (e) {
-				const detailedError = new Error(
+				if (e instanceof UpdatesLockedError) {
+					// Forward the UpdatesLockedError directly
+					throw e;
+				}
+				throw new Error(
 					'Failed to apply state transition steps. ' +
 						e.message +
 						' Steps:' +
 						JSON.stringify(_.map(steps, 'action')),
 				);
-				return this.applyError(detailedError, {
-					force,
-					initial,
-					intermediate,
-				});
 			}
 		}).catch(err => {
 			return this.applyError(err, { force, initial, intermediate });


### PR DESCRIPTION
We do this as there is tooling around the other parts of the engine which works upon these errors.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>