### PR TITLE
Support matching on device type within contracts

### DIFF
--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -3,7 +3,9 @@ import Config, { ConfigKey } from './config';
 import Database from './db';
 import DeviceState from './device-state';
 import EventTracker from './event-tracker';
+import { intialiseContractRequirements } from './lib/contracts';
 import { normaliseLegacyDatabase } from './lib/migration';
+import * as osRelease from './lib/os-release';
 import Logger from './logger';
 import SupervisorAPI from './supervisor-api';
 
@@ -91,6 +93,12 @@ export class Supervisor {
 			enableLogs: conf.loggingEnabled,
 			config: this.config,
 			...conf,
+		});
+
+		intialiseContractRequirements({
+			supervisorVersion: version,
+			deviceType: await this.config.get('deviceType'),
+			l4tVersion: await osRelease.getL4tVersion(),
 		});
 
 		log.debug('Starting api binder');

--- a/test/05-device-state.spec.ts
+++ b/test/05-device-state.spec.ts
@@ -17,6 +17,7 @@ import DeviceState from '../src/device-state';
 import { loadTargetFromFile } from '../src/device-state/preload';
 
 import Service from '../src/compose/service';
+import { intialiseContractRequirements } from '../src/lib/contracts';
 
 const mockedInitialConfig = {
 	RESIN_SUPERVISOR_CONNECTIVITY_CHECK: 'true',
@@ -225,6 +226,11 @@ describe('deviceState', () => {
 		stub(Service as any, 'extendEnvVars').callsFake(env => {
 			env['ADDITIONAL_ENV_VAR'] = 'foo';
 			return env;
+		});
+
+		intialiseContractRequirements({
+			supervisorVersion: '11.0.0',
+			deviceType: 'intel-nuc',
 		});
 
 		deviceState = new DeviceState({


### PR DESCRIPTION
It looks like a bunch of changes, but in reality there's only really two;
* We change the way we setup the contract engine, requiring it to not be async anymore. We do this to avoid having to have the contract engine know about the `config/` stuff.
* We add device-type matching to the contract engine

Closes: #1191
Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>