### PR TITLE
Add a random constant offset to every poll timeout

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -608,9 +608,10 @@ export class APIBinder {
 			instantUpdates,
 		} = await this.config.getMany(['appUpdatePollInterval', 'instantUpdates']);
 
-		// We add jitter to the poll interval so that it's between 0.5 and 1.5 times
-		// the configured interval
-		let pollInterval = (0.5 + Math.random()) * appUpdatePollInterval;
+		// We add a random jitter up to `maxApiJitterDelay` to
+		// space out poll requests
+		let pollInterval =
+			Math.random() * constants.maxApiJitterDelay + appUpdatePollInterval;
 
 		if (instantUpdates || !isInitialCall) {
 			try {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -58,6 +58,10 @@ const constants = {
 	supervisorNetworkGateway: '10.114.104.1',
 	// How often can we report our state to the server in ms
 	maxReportFrequency: 10 * 1000,
+	// How much of a jitter we can add to our api polling
+	// (this number is used as an upper bound when generating
+	// a random jitter)
+	maxApiJitterDelay: 60 * 1000,
 };
 
 if (process.env.DOCKER_HOST == null) {


### PR DESCRIPTION
This allows us to space out the requests from a fleet, but also ensures
that the pollInterval is a minimum, rather than the centre value between
0.5* and 1.5*

Closes: #1242
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>