### PR TITLE
Don't use the openvpn alias to check VPN status

### DIFF
--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -14,7 +14,7 @@ import { EnvVarObject } from './lib/types';
 import { checkInt, checkTruthy } from './lib/validation';
 import { DeviceStatus } from './types/state';
 
-const vpnServiceName = 'openvpn-resin';
+const vpnServiceName = 'openvpn';
 
 interface DeviceConfigConstructOpts {
 	db: Database;


### PR DESCRIPTION
This still maintains compatibility with post-MC balenaOS versions, as all of those versions used `openvpn` as the service name proper. 

Closes: #1293
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>