### PR TITLE
log healthcheck failure

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -1,5 +1,6 @@
 import * as Bluebird from 'bluebird';
 import * as bodyParser from 'body-parser';
+import { stripIndent } from 'common-tags';
 import * as express from 'express';
 import { isLeft } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
@@ -113,24 +114,49 @@ export class APIBinder {
 			'connectivityCheckEnabled',
 		]);
 
+		// Don't have to perform checks for unmanaged
 		if (unmanaged) {
 			return true;
 		}
 
 		if (appUpdatePollInterval == null) {
+			log.info(
+				'Healthcheck failure - Config value `appUpdatePollInterval` cannot be null',
+			);
 			return false;
 		}
 
+		// Check last time target state has been polled
 		const timeSinceLastFetch = process.hrtime(this.lastTargetStateFetch);
 		const timeSinceLastFetchMs =
 			timeSinceLastFetch[0] * 1000 + timeSinceLastFetch[1] / 1e6;
-		const stateFetchHealthy = timeSinceLastFetchMs < 2 * appUpdatePollInterval;
+
+		if (!(timeSinceLastFetchMs < 2 * appUpdatePollInterval)) {
+			log.info(
+				'Healthcheck failure - Device has not fetched target state within appUpdatePollInterval limit',
+			);
+			return false;
+		}
+
+		// Check if state report is healthy
 		const stateReportHealthy =
 			!connectivityCheckEnabled ||
 			!this.deviceState.connected ||
 			this.stateReportErrors < 3;
 
-		return stateFetchHealthy && stateReportHealthy;
+		if (!stateReportHealthy) {
+			log.info(
+				stripIndent`
+				Healthcheck failure - Atleast ONE of the following conditions must be true:
+					- No connectivityCheckEnabled   ? ${!(connectivityCheckEnabled === true)}
+					- device state is disconnected  ? ${!(this.deviceState.connected === true)}
+					- stateReportErrors less then 3 ? ${this.stateReportErrors < 3}`,
+			);
+			return false;
+		}
+
+		// All tests pass!
+		return true;
 	}
 
 	public async initClient() {

--- a/test/11-api-binder.spec.ts
+++ b/test/11-api-binder.spec.ts
@@ -286,8 +286,8 @@ describe('ApiBinder', () => {
 		let configStub: SinonStub;
 		let infoLobSpy: SinonSpy;
 
-		before(() => {
-			initModels(components, '/config-apibinder.json');
+		before(async () => {
+			await initModels(components, '/config-apibinder.json');
 		});
 
 		beforeEach(() => {

--- a/test/data/device-api-responses.json
+++ b/test/data/device-api-responses.json
@@ -1,5 +1,18 @@
 {
-  "V1": {},
+  "V1": {
+    "GET": {
+      "/healthy": {
+        "statusCode": 200,
+        "body": {},
+        "text": "OK"
+      },
+      "/healthy [2]": {
+        "statusCode": 500,
+        "body": {},
+        "text": "Unhealthy"
+      }
+    }
+  },
   "V2": {
     "GET": {
       "/device/vpn": {

--- a/test/lib/mocked-device-api.ts
+++ b/test/lib/mocked-device-api.ts
@@ -11,6 +11,7 @@ import Config from '../../src/config';
 import * as db from '../../src/db';
 import { createV1Api } from '../../src/device-api/v1';
 import { createV2Api } from '../../src/device-api/v2';
+import APIBinder from '../../src/api-binder';
 import DeviceState from '../../src/device-state';
 import EventTracker from '../../src/event-tracker';
 import SupervisorAPI from '../../src/supervisor-api';
@@ -67,7 +68,12 @@ const STUBBED_VALUES = {
 
 async function create(): Promise<SupervisorAPI> {
 	// Get SupervisorAPI construct options
-	const { config, eventTracker, deviceState } = await createAPIOpts();
+	const {
+		config,
+		eventTracker,
+		deviceState,
+		apiBinder,
+	} = await createAPIOpts();
 	// Stub functions
 	setupStubs();
 	// Create ApplicationManager
@@ -83,7 +89,7 @@ async function create(): Promise<SupervisorAPI> {
 		config,
 		eventTracker,
 		routers: [buildRoutes(appManager)],
-		healthchecks: [],
+		healthchecks: [deviceState.healthcheck, apiBinder.healthcheck],
 	});
 	// Return SupervisorAPI that is not listening yet
 	return api;
@@ -115,10 +121,16 @@ async function createAPIOpts(): Promise<SupervisorAPIOpts> {
 		logger: null as any,
 		apiBinder: null as any,
 	});
+	const apiBinder = new APIBinder({
+		config: mockedConfig,
+		eventTracker: tracker,
+		logger: null as any,
+	});
 	return {
 		config: mockedConfig,
 		eventTracker: tracker,
 		deviceState,
+		apiBinder,
 	};
 }
 
@@ -168,6 +180,7 @@ interface SupervisorAPIOpts {
 	config: Config;
 	eventTracker: EventTracker;
 	deviceState: DeviceState;
+	apiBinder: APIBinder;
 }
 
 export = { create, cleanUp, STUBBED_VALUES };


### PR DESCRIPTION
This PR makes sure whatever causes the healthchecks used by GET /v1/healthy to not pass by logged via Log.info so that debugging this can be easier.

The PR includes added test coverage for the API endpoint as well as the healthcheck functions themselves that re called from this endpoint.

Closes: #1292 