### PR TITLE
Use safeStateClone to avoid call-stack exceeding errors

### DIFF
--- a/src/device-api/common.d.ts
+++ b/src/device-api/common.d.ts
@@ -1,5 +1,6 @@
 import ApplicationManager from '../application-manager';
 import { Service } from '../compose/service';
+import { InstancedDeviceState } from '../types/state';
 
 export interface ServiceAction {
 	action: string;
@@ -28,3 +29,10 @@ declare function serviceAction(
 	target?: Service,
 	options?: any,
 ): ServiceAction;
+
+declare function safeStateClone(
+	targetState: InstancedDeviceState,
+	// Use an any here, because it's not an InstancedDeviceState,
+	// and it's also not the exact same type as the API serves from
+	// state endpoint (more details in the function)
+): Dictionary<any>;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>