### PR TITLE
Move database app processing out to its own module

### DIFF
--- a/src/application-manager.d.ts
+++ b/src/application-manager.d.ts
@@ -64,7 +64,7 @@ class ApplicationManager extends EventEmitter {
 
 	public init(): Promise<void>;
 
-	public getCurrentApp(appId: number): Bluebird<Application | null>;
+	public getCurrentApp(appId: number): Promise<Application | null>;
 
 	// TODO: This actually returns an object, but we don't need the values just yet
 	public setTargetVolatileForService(serviceId: number, opts: Options): void;
@@ -90,7 +90,7 @@ class ApplicationManager extends EventEmitter {
 	public getTargetApps(): Promise<InstancedAppState>;
 	public stopAll(opts: { force?: boolean; skipLock?: boolean }): Promise<void>;
 
-	public serviceNameFromId(serviceId: number): Bluebird<string>;
+	public serviceNameFromId(serviceId: number): Promise<string>;
 	public imageForService(svc: any): Image;
 	public getDependentTargets(): Promise<any>;
 	public getCurrentForComparison(): Promise<any>;

--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -107,8 +107,7 @@ export class Service {
 		delete appConfig.releaseId;
 		service.serviceId = intOrNull(appConfig.serviceId);
 		delete appConfig.serviceId;
-		service.imageName = appConfig.imageName;
-		delete appConfig.imageName;
+		service.imageName = appConfig.image;
 		service.dependsOn = appConfig.dependsOn || null;
 		delete appConfig.dependsOn;
 		service.createdAt = appConfig.createdAt;
@@ -414,6 +413,12 @@ export class Service {
 			tty: true,
 			running: true,
 		});
+
+		// If we have the docker image ID, we replace the image
+		// with that
+		if (options.imageInfo?.Id != null) {
+			config.image = options.imageInfo.Id;
+		}
 
 		// Mutate service with extra features
 		ComposeUtils.addFeaturesFromLabels(service, options);

--- a/src/device-state/db-format.ts
+++ b/src/device-state/db-format.ts
@@ -1,0 +1,185 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as _ from 'lodash';
+import type { ImageInspectInfo } from 'dockerode';
+
+import * as config from '../config';
+import * as db from '../db';
+import * as targetStateCache from '../device-state/target-state-cache';
+import constants = require('../lib/constants');
+import { pathExistsOnHost } from '../lib/fs-utils';
+import * as dockerUtils from '../lib/docker-utils';
+import { NotFoundError } from '../lib/errors';
+
+import Service from '../compose/service';
+import Network from '../compose/network';
+import Volume from '../compose/volume';
+import type {
+	DeviceMetadata,
+	ServiceComposeConfig,
+} from '../compose/types/service';
+import * as images from '../compose/images';
+
+import { InstancedAppState, TargetApplication } from '../types/state';
+import { checkInt } from '../lib/validation';
+
+type InstancedApp = InstancedAppState[0];
+
+// Fetch and instance an app from the db. Throws if the requested appId cannot be found.
+// Currently this function does quite a bit more than it needs to as it pulls in a bunch
+// of required information for the instances but we should think about a method of not
+// requiring that data here
+export async function getApp(id: number): Promise<InstancedApp> {
+	const dbApp = await getDBEntry(id);
+	return await buildApp(dbApp);
+}
+
+export async function getApps(): Promise<InstancedAppState> {
+	const dbApps = await getDBEntry();
+	const apps: InstancedAppState = {};
+	for (const app of dbApps) {
+		apps[app.appId] = await buildApp(app);
+	}
+	return apps;
+}
+
+async function buildApp(dbApp: targetStateCache.DatabaseApp) {
+	const volumes = _.mapValues(JSON.parse(dbApp.volumes) ?? {}, (conf, name) => {
+		if (conf == null) {
+			conf = {};
+		}
+		if (conf.labels == null) {
+			conf.labels = {};
+		}
+		return Volume.fromComposeObject(name, dbApp.appId, conf);
+	});
+
+	const networks = _.mapValues(
+		JSON.parse(dbApp.networks) ?? {},
+		(conf, name) => {
+			if (conf == null) {
+				conf = {};
+			}
+			return Network.fromComposeObject(name, dbApp.appId, conf);
+		},
+	);
+
+	const opts = await config.get('extendedEnvOptions');
+	const supervisorApiHost = dockerUtils
+		.getNetworkGateway(constants.supervisorNetworkInterface)
+		.catch(() => '127.0.0.1');
+	const hostPathExists = {
+		firmware: await pathExistsOnHost('/lib/firmware'),
+		modules: await pathExistsOnHost('/lib/modules'),
+	};
+	const hostnameOnHost = _.trim(
+		await fs.readFile(
+			path.join(constants.rootMountPoint, '/etc/hostname'),
+			'utf8',
+		),
+	);
+
+	const svcOpts = {
+		appName: dbApp.name,
+		supervisorApiHost,
+		hostPathExists,
+		hostnameOnHost,
+		...opts,
+	};
+
+	// In the db, the services are an array, but here we switch them to an
+	// object so that they are consistent
+	const services = _.keyBy(
+		await Promise.all(
+			(JSON.parse(dbApp.services) ?? []).map(
+				async (svc: ServiceComposeConfig) => {
+					// Try to fill the image id if the image is downloaded
+					let imageInfo: ImageInspectInfo | undefined;
+					try {
+						imageInfo = await images.inspectByName(svc.image);
+					} catch (e) {
+						if (NotFoundError(e)) {
+							imageInfo = undefined;
+						} else {
+							throw e;
+						}
+					}
+
+					const thisSvcOpts = {
+						...svcOpts,
+						imageInfo,
+						serviceName: svc.serviceName,
+					};
+					// We force the casting here as we know that the UUID exists, but the typings do
+					// not
+					return Service.fromComposeObject(
+						svc,
+						(thisSvcOpts as unknown) as DeviceMetadata,
+					);
+				},
+			),
+		),
+		'serviceId',
+	) as Dictionary<Service>;
+
+	return {
+		appId: dbApp.appId,
+		commit: dbApp.commit,
+		releaseId: dbApp.releaseId,
+		name: dbApp.name,
+		source: dbApp.source,
+
+		services,
+		volumes,
+		networks,
+	};
+}
+
+export async function setApps(
+	apps: { [appId: number]: TargetApplication },
+	source: string,
+	trx?: db.Transaction,
+) {
+	const cloned = _.cloneDeep(apps);
+
+	const dbApps = await Promise.all(
+		Object.keys(cloned).map(async (appIdStr) => {
+			const appId = checkInt(appIdStr)!;
+
+			const app = cloned[appId];
+			const services = await Promise.all(
+				_.map(app.services, async (s, sId) => ({
+					...s,
+					appId,
+					releaseId: app.releaseId,
+					serviceId: checkInt(sId),
+					commit: app.commit,
+					image: await images.normalise(s.image),
+				})),
+			);
+
+			return {
+				appId,
+				source,
+				commit: app.commit,
+				name: app.name,
+				releaseId: app.releaseId,
+				services: JSON.stringify(services),
+				networks: JSON.stringify(app.networks ?? {}),
+				volumes: JSON.stringify(app.volumes ?? {}),
+			};
+		}),
+	);
+	await targetStateCache.setTargetApps(dbApps, trx);
+}
+
+function getDBEntry(): Promise<targetStateCache.DatabaseApp[]>;
+function getDBEntry(appId: number): Promise<targetStateCache.DatabaseApp>;
+async function getDBEntry(appId?: number) {
+	await config.initialized;
+	await targetStateCache.initialized;
+
+	return appId != null
+		? targetStateCache.getTargetApp(appId)
+		: targetStateCache.getTargetApps();
+}

--- a/src/device-state/target-state-cache.ts
+++ b/src/device-state/target-state-cache.ts
@@ -4,71 +4,78 @@ import { ApplicationManager } from '../application-manager';
 import * as config from '../config';
 import * as db from '../db';
 
-// Once we have correct types for both applications and the
-// incoming target state this should be changed
-export type DatabaseApp = Dictionary<any>;
+// We omit the id (which does appear in the db) in this type, as we don't use it
+// at all, and we can use the below type for both insertion and retrieval.
+export interface DatabaseApp {
+	name: string;
+	releaseId: number;
+	commit: string;
+	appId: number;
+	services: string;
+	networks: string;
+	volumes: string;
+	source: string;
+}
 export type DatabaseApps = DatabaseApp[];
 
 /*
- * This class is a wrapper around the database setting and
- * receiving of target state. Because the target state can
- * only be set from a single place, but several workflows
- * rely on getting the target state at one point or another,
- * we cache the values using this class. Accessing the
- * database is inherently expensive, and for example the
- * local log backend accesses the target state for every log
- * line. This can very quickly cause serious memory problems
- * and database connection timeouts.
+ * This module is a wrapper around the database fetching and retrieving of
+ * target state. Because the target state can only be set only be set from a
+ * single place, but several workflows rely on getting the target state at one
+ * point or another, we cache the values using this class. Accessing the
+ * database is inherently expensive, and for example the local log backend
+ * accesses the target state for every log line. This can very quickly cause
+ * serious memory problems and database connection timeouts.
  */
-export class TargetStateAccessor {
-	private targetState?: DatabaseApps;
+let targetState: DatabaseApps | undefined;
 
-	public constructor(protected applications: ApplicationManager) {
-		// If we switch backend, the target state also needs to
-		// be invalidated (this includes switching to and from
-		// local mode)
-		config.on('change', (conf) => {
-			if (conf.apiEndpoint != null || conf.localMode != null) {
-				this.targetState = undefined;
-			}
-		});
-	}
-
-	public async getTargetApp(appId: number): Promise<DatabaseApp | undefined> {
-		if (this.targetState == null) {
-			// TODO: Perhaps only fetch a single application from
-			// the DB, at the expense of repeating code
-			await this.getTargetApps();
+export const initialized = (async () => {
+	await db.initialized;
+	await config.initialized;
+	// If we switch backend, the target state also needs to
+	// be invalidated (this includes switching to and from
+	// local mode)
+	config.on('change', (conf) => {
+		if (conf.apiEndpoint != null || conf.localMode != null) {
+			targetState = undefined;
 		}
+	});
+})();
 
-		return _.find(this.targetState, (app) => app.appId === appId);
+export async function getTargetApp(
+	appId: number,
+): Promise<DatabaseApp | undefined> {
+	if (targetState == null) {
+		// TODO: Perhaps only fetch a single application from
+		// the DB, at the expense of repeating code
+		await getTargetApps();
 	}
 
-	public async getTargetApps(): Promise<DatabaseApps> {
-		if (this.targetState == null) {
-			const { apiEndpoint, localMode } = await config.getMany([
-				'apiEndpoint',
-				'localMode',
-			]);
-
-			const source = localMode ? 'local' : apiEndpoint;
-			this.targetState = await db.models('app').where({ source });
-		}
-		return this.targetState!;
-	}
-
-	public async setTargetApps(
-		apps: DatabaseApps,
-		trx: db.Transaction,
-	): Promise<void> {
-		// We can't cache the value here, as it could be for a
-		// different source
-		this.targetState = undefined;
-
-		await Promise.all(
-			apps.map((app) => db.upsertModel('app', app, { appId: app.appId }, trx)),
-		);
-	}
+	return _.find(targetState, (app) => app.appId === appId);
 }
 
-export default TargetStateAccessor;
+export async function getTargetApps(): Promise<DatabaseApps> {
+	if (targetState == null) {
+		const { apiEndpoint, localMode } = await config.getMany([
+			'apiEndpoint',
+			'localMode',
+		]);
+
+		const source = localMode ? 'local' : apiEndpoint;
+		targetState = await db.models('app').where({ source });
+	}
+	return targetState!;
+}
+
+export async function setTargetApps(
+	apps: DatabaseApps,
+	trx?: db.Transaction,
+): Promise<void> {
+	// We can't cache the value here, as it could be for a
+	// different source
+	targetState = undefined;
+
+	await Promise.all(
+		apps.map((app) => db.upsertModel('app', app, { appId: app.appId }, trx)),
+	);
+}

--- a/src/device-state/target-state-cache.ts
+++ b/src/device-state/target-state-cache.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 
-import { ApplicationManager } from '../application-manager';
 import * as config from '../config';
 import * as db from '../db';
 

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -18,12 +18,12 @@ import { BackupError, DatabaseParseError, NotFoundError } from '../lib/errors';
 import { docker } from '../lib/docker-utils';
 import { pathExistsOnHost } from '../lib/fs-utils';
 import { log } from '../lib/supervisor-console';
-import {
-	ApplicationDatabaseFormat,
+import type {
 	AppsJsonFormat,
 	TargetApplication,
 	TargetState,
 } from '../types/state';
+import type { DatabaseApp } from '../device-state/target-state-cache';
 
 export const defaultLegacyVolume = () => 'resin-data';
 
@@ -113,7 +113,7 @@ export async function normaliseLegacyDatabase(
 	// When legacy apps are present, we kill their containers and migrate their /data to a named volume
 	log.info('Migrating ids for legacy app...');
 
-	const apps: ApplicationDatabaseFormat = await db.models('app').select();
+	const apps: DatabaseApp[] = await db.models('app').select();
 
 	if (apps.length === 0) {
 		log.debug('No app to migrate');

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -96,17 +96,6 @@ export type AppsJsonFormat = Omit<TargetState['local'], 'name'> & {
 	pinDevice?: boolean;
 };
 
-export type ApplicationDatabaseFormat = Array<{
-	appId: number;
-	commit: string;
-	name: string;
-	source: string;
-	releaseId: number;
-	services: string;
-	networks: string;
-	volumes: string;
-}>;
-
 // This structure is the internal representation of both
 // target and current state. We create instances of compose
 // objects and these are what the state engine uses to
@@ -117,7 +106,8 @@ export interface InstancedAppState {
 		commit: string;
 		releaseId: number;
 		name: string;
-		services: Service[];
+		source: string;
+		services: Dictionary<Service>;
 		volumes: Dictionary<Volume>;
 		networks: Dictionary<Network>;
 	};

--- a/test/28-db-format.spec.ts
+++ b/test/28-db-format.spec.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import prepare = require('./lib/prepare');
+
+import * as config from '../src/config';
+import * as dbFormat from '../src/device-state/db-format';
+import * as targetStateCache from '../src/device-state/target-state-cache';
+import * as images from '../src/compose/images';
+
+import Service from '../src/compose/service';
+import { TargetApplication } from '../src/types/state';
+
+describe('DB Format', () => {
+	const originalInspect = images.inspectByName;
+	let apiEndpoint: string;
+	before(async () => {
+		await prepare();
+		await config.initialized;
+		await targetStateCache.initialized;
+
+		apiEndpoint = await config.get('apiEndpoint');
+
+		// Setup some mocks
+		// @ts-expect-error Assigning to a RO property
+		images.inspectByName = () => {
+			const error = new Error();
+			// @ts-ignore
+			error.statusCode = 404;
+			return Promise.reject(error);
+		};
+		await targetStateCache.setTargetApps([
+			{
+				appId: 1,
+				commit: 'abcdef',
+				name: 'test-app',
+				source: apiEndpoint,
+				releaseId: 123,
+				services: '[]',
+				networks: '{}',
+				volumes: '{}',
+			},
+			{
+				appId: 2,
+				commit: 'abcdef2',
+				name: 'test-app2',
+				source: apiEndpoint,
+				releaseId: 1232,
+				services: JSON.stringify([
+					{
+						serviceName: 'test-service',
+						image: 'test-image',
+						imageId: 5,
+						environment: {
+							TEST_VAR: 'test-string',
+						},
+						tty: true,
+						appId: 2,
+						releaseId: 1232,
+						serviceId: 567,
+						commit: 'abcdef2',
+					},
+				]),
+				networks: '{}',
+				volumes: '{}',
+			},
+		]);
+	});
+
+	after(async () => {
+		await prepare();
+
+		// @ts-expect-error Assigning to a RO property
+		images.inspectByName = originalInspect;
+	});
+
+	it('should retrieve a single app from the database', async () => {
+		const app = await dbFormat.getApp(1);
+		expect(app).to.have.property('appId').that.equals(1);
+		expect(app).to.have.property('commit').that.equals('abcdef');
+		expect(app).to.have.property('releaseId').that.equals(123);
+		expect(app).to.have.property('name').that.equals('test-app');
+		expect(app)
+			.to.have.property('source')
+			.that.deep.equals(await config.get('apiEndpoint'));
+		expect(app).to.have.property('services').that.deep.equals({});
+		expect(app).to.have.property('volumes').that.deep.equals({});
+		expect(app).to.have.property('networks').that.deep.equals({});
+	});
+
+	it('should correctly build services from the database', async () => {
+		const app = await dbFormat.getApp(2);
+		expect(app).to.have.property('services').that.is.an('object');
+		expect(Object.keys(app.services)).to.deep.equal(['567']);
+
+		const service = app.services['567'];
+		expect(service).to.be.instanceof(Service);
+		// Don't do a deep equals here as a bunch of other properties are added that are
+		// tested elsewhere
+		expect(service.config)
+			.to.have.property('environment')
+			.that.has.property('TEST_VAR')
+			.that.equals('test-string');
+		expect(service.config).to.have.property('tty').that.equals(true);
+		expect(service).to.have.property('imageName').that.equals('test-image');
+		expect(service).to.have.property('imageId').that.equals(5);
+	});
+
+	it('should retrieve multiple apps from the database', async () => {
+		const apps = await dbFormat.getApps();
+		expect(Object.keys(apps)).to.have.length(2).and.deep.equal(['1', '2']);
+	});
+
+	it('should write target states to the database', async () => {
+		const target = await import('./data/state-endpoints/simple.json');
+		const dbApps: { [appId: number]: TargetApplication } = {};
+		dbApps[1234] = {
+			...target.local.apps[1234],
+		};
+
+		await dbFormat.setApps(dbApps, apiEndpoint);
+
+		const app = await dbFormat.getApp(1234);
+
+		expect(app).to.have.property('name').that.equals('pi4test');
+		expect(app).to.have.property('services').that.is.an('object');
+		expect(app.services)
+			.to.have.property('482141')
+			.that.has.property('serviceName')
+			.that.equals('main');
+	});
+
+	it('should add default and missing fields when retreiving from the database', async () => {
+		const originalImagesInspect = images.inspectByName;
+		try {
+			// @ts-expect-error Assigning a RO property
+			images.inspectByName = () =>
+				Promise.resolve({
+					Config: { Cmd: ['someCommand'], Entrypoint: ['theEntrypoint'] },
+				});
+
+			const app = await dbFormat.getApp(2);
+			const conf = app.services[Object.keys(app.services)[0]].config;
+			expect(conf)
+				.to.have.property('entrypoint')
+				.that.deep.equals(['theEntrypoint']);
+			expect(conf)
+				.to.have.property('command')
+				.that.deep.equals(['someCommand']);
+		} finally {
+			// @ts-expect-error Assigning a RO property
+			images.inspectByName = originalImagesInspect;
+		}
+	});
+});

--- a/test/data/state-endpoints/simple.json
+++ b/test/data/state-endpoints/simple.json
@@ -1,0 +1,56 @@
+
+{
+  "local": {
+    "name": "lingering-frost",
+    "config": {
+      "RESIN_SUPERVISOR_DELTA_VERSION": "3",
+      "RESIN_SUPERVISOR_NATIVE_LOGGER": "true",
+      "RESIN_HOST_CONFIG_arm_64bit": "1",
+      "RESIN_HOST_CONFIG_disable_splash": "1",
+      "RESIN_HOST_CONFIG_dtoverlay": "\"vc4-fkms-v3d\"",
+      "RESIN_HOST_CONFIG_dtparam": "\"i2c_arm=on\",\"spi=on\",\"audio=on\"",
+      "RESIN_HOST_CONFIG_enable_uart": "1",
+      "RESIN_HOST_CONFIG_gpu_mem": "16",
+      "RESIN_SUPERVISOR_DELTA": "1",
+      "RESIN_SUPERVISOR_POLL_INTERVAL": "900000"
+    },
+    "apps": {
+      "1234": {
+        "name": "pi4test",
+        "commit": "d0b7b1d5353c4a1d9d411614caf827f5",
+        "releaseId": 1405939,
+        "services": {
+          "482141": {
+            "privileged": true,
+            "tty": true,
+            "restart": "always",
+            "network_mode": "host",
+            "volumes": [
+              "resin-data:/data"
+            ],
+            "labels": {
+              "io.resin.features.dbus": "1",
+              "io.resin.features.firmware": "1",
+              "io.resin.features.kernel-modules": "1",
+              "io.resin.features.resin-api": "1",
+              "io.resin.features.supervisor-api": "1"
+            },
+            "imageId": 2339002,
+            "serviceName": "main",
+            "image": "registry2.balena-cloud.com/v2/f5aff5560e1fb6740a868bfe2e8a4684@sha256:9cd1d09aad181b98067dac95e08f121c3af16426f078c013a485c41a63dc035c",
+            "running": true,
+            "environment": {}
+          }
+        },
+        "volumes": {
+          "resin-data": {}
+        },
+        "networks": {}
+      }
+    }
+  },
+  "dependent": {
+    "apps": {},
+    "devices": {}
+  }
+}

--- a/test/lib/application-manager-test-states.ts
+++ b/test/lib/application-manager-test-states.ts
@@ -13,8 +13,8 @@ targetState[0] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
@@ -52,7 +52,7 @@ targetState[0] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -64,8 +64,8 @@ targetState[1] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
@@ -90,7 +90,7 @@ targetState[1] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -102,8 +102,8 @@ targetState[2] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
@@ -144,7 +144,7 @@ targetState[2] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -156,8 +156,8 @@ targetState[3] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
@@ -199,7 +199,7 @@ targetState[3] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -211,8 +211,8 @@ targetState[4] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
@@ -253,7 +253,7 @@ targetState[4] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -265,8 +265,8 @@ targetState[5] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
@@ -306,7 +306,7 @@ targetState[5] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -315,8 +315,8 @@ targetState[6] = {
 	local: {
 		name: 'volumeTest',
 		config: {},
-		apps: [
-			{
+		apps: {
+			12345: {
 				appId: 12345,
 				name: 'volumeApp',
 				commit: 'asd',
@@ -325,7 +325,7 @@ targetState[6] = {
 				volumes: {},
 				networks: {},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -338,14 +338,14 @@ currentState[0] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
 				releaseId: 2,
-				services: [
-					{
+				services: {
+					23: {
 						appId: 1234,
 						serviceId: 23,
 						releaseId: 2,
@@ -377,7 +377,7 @@ currentState[0] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-					{
+					24: {
 						appId: 1234,
 						serviceId: 24,
 						releaseId: 2,
@@ -409,11 +409,11 @@ currentState[0] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-				],
+				},
 				volumes: {},
 				networks: { default: {} },
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -425,17 +425,17 @@ currentState[1] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
 				releaseId: 2,
-				services: [],
+				services: {},
 				volumes: {},
 				networks: { default: {} },
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -447,14 +447,14 @@ currentState[2] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
 				releaseId: 2,
-				services: [
-					{
+				services: {
+					23: {
 						appId: 1234,
 						serviceId: 23,
 						releaseId: 2,
@@ -488,11 +488,11 @@ currentState[2] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-				],
+				},
 				volumes: {},
 				networks: { default: {} },
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -504,14 +504,14 @@ currentState[3] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
 				releaseId: 2,
-				services: [
-					{
+				services: {
+					23: {
 						appId: 1234,
 						serviceId: 23,
 						serviceName: 'aservice',
@@ -545,7 +545,7 @@ currentState[3] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-					{
+					24: {
 						appId: 1234,
 						serviceId: 23,
 						serviceName: 'aservice',
@@ -579,11 +579,11 @@ currentState[3] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-				],
+				},
 				volumes: {},
 				networks: { default: {} },
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -595,14 +595,14 @@ currentState[4] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
 				releaseId: 2,
-				services: [
-					{
+				services: {
+					24: {
 						appId: 1234,
 						serviceId: 24,
 						releaseId: 2,
@@ -634,11 +634,11 @@ currentState[4] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-				],
+				},
 				volumes: {},
 				networks: { default: {} },
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -647,28 +647,28 @@ currentState[5] = {
 	local: {
 		name: 'volumeTest',
 		config: {},
-		apps: [
-			{
+		apps: {
+			12345: {
 				appId: 12345,
 				name: 'volumeApp',
 				commit: 'asd',
 				releaseId: 3,
-				services: [],
+				services: {},
 				volumes: {},
 				networks: { default: {} },
 			},
-			{
+			12: {
 				appId: 12,
 				name: 'previous-app',
 				commit: '123',
 				releaseId: 10,
-				services: [],
+				services: {},
 				networks: {},
 				volumes: {
 					my_volume: {},
 				},
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };
@@ -680,14 +680,14 @@ currentState[6] = {
 			RESIN_HOST_CONFIG_gpu_mem: '512',
 			RESIN_HOST_LOG_TO_DISPLAY: '1',
 		},
-		apps: [
-			{
+		apps: {
+			1234: {
 				appId: 1234,
 				name: 'superapp',
 				commit: 'afafafa',
 				releaseId: 2,
-				services: [
-					{
+				services: {
+					23: {
 						appId: 1234,
 						serviceId: 23,
 						releaseId: 2,
@@ -719,7 +719,7 @@ currentState[6] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-					{
+					24: {
 						appId: 1234,
 						serviceId: 24,
 						releaseId: 2,
@@ -751,11 +751,11 @@ currentState[6] = {
 						command: ['someCommand'],
 						entrypoint: ['theEntrypoint'],
 					},
-				],
+				},
 				volumes: {},
 				networks: { default: {} },
 			},
-		],
+		},
 	},
 	dependent: { apps: [], devices: [] },
 };


### PR DESCRIPTION
This is part of the work to make the application-manager module much
less monolithic, in preparation for system apps and more generally
multi-app.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>
