### PR TITLE
Use API v6

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -153,7 +153,7 @@ export class APIBinder {
 			return;
 		}
 
-		const baseUrl = url.resolve(apiEndpoint, '/v5/');
+		const baseUrl = url.resolve(apiEndpoint, '/v6/');
 		const passthrough = _.cloneDeep(await request.getRequestOptions());
 		passthrough.headers =
 			passthrough.headers != null ? passthrough.headers : {};

--- a/test/lib/mocked-balena-api.ts
+++ b/test/lib/mocked-balena-api.ts
@@ -51,7 +51,7 @@ api.post('/device/register', (req, res) =>
 	api.balenaBackend!.registerHandler(req, res, _.noop),
 );
 
-api.get('/v5/device', (req, res) =>
+api.get('/v6/device', (req, res) =>
 	api.balenaBackend!.getDeviceHandler(req, res, _.noop),
 );
 


### PR DESCRIPTION
open-balena-api still only exposes v5, but I'd like to get the ball rolling as it'll take a while until the new Supervisor makes it into a new stable balenaOS release.

See: https://github.com/balena-io/open-balena/issues/80
Change-type: minor