### PR TITLE
bug: Fix unhandled promise rejection

### DIFF
--- a/test/13-device-config.spec.ts
+++ b/test/13-device-config.spec.ts
@@ -1,6 +1,6 @@
 import { stripIndent } from 'common-tags';
 import { child_process, fs } from 'mz';
-import { SinonStub, stub, spy } from 'sinon';
+import { SinonStub, stub, spy, SinonSpy } from 'sinon';
 
 import { expect } from './lib/chai-config';
 import * as deviceConfig from '../src/device-config';
@@ -14,9 +14,10 @@ const extlinuxBackend = new ExtlinuxConfigBackend();
 const rpiConfigBackend = new RPiConfigBackend();
 
 describe('Device Backend Config', () => {
-	const logSpy = spy(logger, 'logSystemMessage');
+	let logSpy: SinonSpy;
 
 	before(async () => {
+		logSpy = spy(logger, 'logSystemMessage');
 		await prepare();
 	});
 


### PR DESCRIPTION
When invoking iptables-restore it can fail. This wasn't handled
and this makes sure that it fails gracefully.

Closes; https://github.com/balena-io/balena-supervisor/issues/1393
Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>