### PR TITLE
Allow multiple config backends

### DIFF
--- a/src/config/backends/backend.ts
+++ b/src/config/backends/backend.ts
@@ -21,7 +21,7 @@ export async function remountAndWriteAtomic(
 	await writeFileAtomic(file, data);
 }
 
-export abstract class DeviceConfigBackend {
+export abstract class ConfigBackend {
 	// Does this config backend support the given device type?
 	public abstract async matches(
 		deviceType: string,
@@ -61,7 +61,7 @@ export abstract class DeviceConfigBackend {
 	public abstract createConfigVarName(configName: string): string | null;
 
 	// Allow a chosen config backend to be initialised
-	public async initialise(): Promise<DeviceConfigBackend> {
+	public async initialise(): Promise<ConfigBackend> {
 		return this;
 	}
 }

--- a/src/config/backends/config-fs.ts
+++ b/src/config/backends/config-fs.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import {
 	ConfigOptions,
-	DeviceConfigBackend,
+	ConfigBackend,
 	bootMountPoint,
 	remountAndWriteAtomic,
 } from './backend';
@@ -21,7 +21,7 @@ import log from '../../lib/supervisor-console';
 
 type ConfigfsConfig = Dictionary<string[]>;
 
-export class ConfigfsConfigBackend extends DeviceConfigBackend {
+export class ConfigFs extends ConfigBackend {
 	private readonly SystemAmlFiles = path.join(
 		constants.rootMountPoint,
 		'boot/acpi-tables',
@@ -129,7 +129,7 @@ export class ConfigfsConfigBackend extends DeviceConfigBackend {
 		}
 	}
 
-	public async initialise(): Promise<ConfigfsConfigBackend> {
+	public async initialise(): Promise<ConfigFs> {
 		try {
 			await super.initialise();
 
@@ -158,7 +158,7 @@ export class ConfigfsConfigBackend extends DeviceConfigBackend {
 	}
 
 	public async matches(deviceType: string): Promise<boolean> {
-		return ConfigfsConfigBackend.SupportedDeviceTypes.includes(deviceType);
+		return ConfigFs.SupportedDeviceTypes.includes(deviceType);
 	}
 
 	public async getBootConfig(): Promise<ConfigOptions> {
@@ -195,15 +195,11 @@ export class ConfigfsConfigBackend extends DeviceConfigBackend {
 	}
 
 	public isSupportedConfig(name: string): boolean {
-		return ConfigfsConfigBackend.BootConfigVars.includes(
-			this.stripPrefix(name),
-		);
+		return ConfigFs.BootConfigVars.includes(this.stripPrefix(name));
 	}
 
 	public isBootConfigVar(name: string): boolean {
-		return ConfigfsConfigBackend.BootConfigVars.includes(
-			this.stripPrefix(name),
-		);
+		return ConfigFs.BootConfigVars.includes(this.stripPrefix(name));
 	}
 
 	public processConfigVarName(name: string): string {

--- a/src/config/backends/index.ts
+++ b/src/config/backends/index.ts
@@ -1,0 +1,11 @@
+import { Extlinux } from './extlinux';
+import { ExtraUEnv } from './extra-uEnv';
+import { ConfigTxt } from './config-txt';
+import { ConfigFs } from './config-fs';
+
+export default [
+	new Extlinux(),
+	new ExtraUEnv(),
+	new ConfigTxt(),
+	new ConfigFs(),
+];

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -3,17 +3,17 @@ import * as _ from 'lodash';
 import * as constants from '../lib/constants';
 import { getMetaOSRelease } from '../lib/os-release';
 import { EnvVarObject } from '../lib/types';
-import { ExtlinuxConfigBackend } from './backends/extlinux';
-import { ExtraUEnvConfigBackend } from './backends/extra-uEnv';
-import { RPiConfigBackend } from './backends/raspberry-pi';
-import { ConfigfsConfigBackend } from './backends/config-fs';
-import { ConfigOptions, DeviceConfigBackend } from './backends/backend';
+import { Extlinux } from './backends/extlinux';
+import { ExtraUEnv } from './backends/extra-uEnv';
+import { ConfigTxt } from './backends/config-txt';
+import { ConfigFs } from './backends/config-fs';
+import { ConfigOptions, ConfigBackend } from './backends/backend';
 
 const configBackends = [
-	new ExtlinuxConfigBackend(),
-	new ExtraUEnvConfigBackend(),
-	new RPiConfigBackend(),
-	new ConfigfsConfigBackend(),
+	new Extlinux(),
+	new ExtraUEnv(),
+	new ConfigTxt(),
+	new ConfigFs(),
 ];
 
 export const initialiseConfigBackend = async (deviceType: string) => {
@@ -26,7 +26,7 @@ export const initialiseConfigBackend = async (deviceType: string) => {
 
 async function getConfigBackend(
 	deviceType: string,
-): Promise<DeviceConfigBackend | undefined> {
+): Promise<ConfigBackend | undefined> {
 	// Some backends are only supported by certain release versions so pass in metaRelease
 	const metaRelease = await getMetaOSRelease(constants.hostOSVersionPath);
 	let matched;
@@ -39,7 +39,7 @@ async function getConfigBackend(
 }
 
 export function envToBootConfig(
-	configBackend: DeviceConfigBackend | null,
+	configBackend: ConfigBackend | null,
 	env: EnvVarObject,
 ): ConfigOptions {
 	if (configBackend == null) {
@@ -56,7 +56,7 @@ export function envToBootConfig(
 }
 
 export function bootConfigToEnv(
-	configBackend: DeviceConfigBackend,
+	configBackend: ConfigBackend,
 	config: ConfigOptions,
 ): EnvVarObject {
 	return _(config)
@@ -85,7 +85,7 @@ function filterNamespaceFromConfig(
 }
 
 export function formatConfigKeys(
-	configBackend: DeviceConfigBackend | null,
+	configBackend: ConfigBackend | null,
 	allowedKeys: string[],
 	conf: { [key: string]: any },
 ): { [key: string]: any } {

--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -6,7 +6,7 @@ import { SchemaTypeKey } from './config/schema-type';
 import * as db from './db';
 import * as logger from './logger';
 
-import { ConfigOptions, DeviceConfigBackend } from './config/backends/backend';
+import { ConfigOptions, ConfigBackend } from './config/backends/backend';
 import * as configUtils from './config/utils';
 import * as dbus from './lib/dbus';
 import { UnitNotLoadedError } from './lib/errors';
@@ -108,7 +108,7 @@ const actionExecutors: DeviceActionExecutors = {
 	},
 };
 
-let configBackend: DeviceConfigBackend | null = null;
+let configBackend: ConfigBackend | null = null;
 
 const configKeys: Dictionary<ConfigOption> = {
 	appUpdatePollInterval: {
@@ -314,7 +314,7 @@ export function resetRateLimits() {
 
 // Exported for tests
 export function bootConfigChangeRequired(
-	$configBackend: DeviceConfigBackend | null,
+	$configBackend: ConfigBackend | null,
 	current: Dictionary<string>,
 	target: Dictionary<string>,
 	deviceType: string,
@@ -492,7 +492,7 @@ export function isValidAction(action: string): boolean {
 }
 
 export async function getBootConfig(
-	backend: DeviceConfigBackend | null,
+	backend: ConfigBackend | null,
 ): Promise<EnvVarObject> {
 	if (backend == null) {
 		return {};
@@ -503,7 +503,7 @@ export async function getBootConfig(
 
 // Exported for tests
 export async function setBootConfig(
-	backend: DeviceConfigBackend | null,
+	backend: ConfigBackend | null,
 	target: Dictionary<string>,
 ) {
 	if (backend == null) {

--- a/test/05-device-state.spec.ts
+++ b/test/05-device-state.spec.ts
@@ -10,7 +10,7 @@ import Log from '../src/lib/supervisor-console';
 import * as dockerUtils from '../src/lib/docker-utils';
 import * as config from '../src/config';
 import * as images from '../src/compose/images';
-import { RPiConfigBackend } from '../src/config/backends/raspberry-pi';
+import { ConfigTxt } from '../src/config/backends/config-txt';
 import DeviceState from '../src/device-state';
 import * as deviceConfig from '../src/device-config';
 import { loadTargetFromFile } from '../src/device-state/preload';
@@ -254,7 +254,7 @@ describe('deviceState', () => {
 		};
 
 		// @ts-expect-error Assigning to a RO property
-		deviceConfig.configBackend = new RPiConfigBackend();
+		deviceConfig.configBackend = new ConfigTxt();
 
 		// @ts-expect-error Assigning to a RO property
 		deviceConfig.getCurrent = async () => mockedInitialConfig;

--- a/test/17-config-utils.spec.ts
+++ b/test/17-config-utils.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from './lib/chai-config';
 import * as configUtils from '../src/config/utils';
-import { RPiConfigBackend } from '../src/config/backends/raspberry-pi';
+import { ConfigTxt } from '../src/config/backends/config-txt';
 
-const rpiBackend = new RPiConfigBackend();
+const configTxtBackend = new ConfigTxt();
 
 describe('Config Utilities', () => {
 	describe('Boot config', () => {
 		it('correctly transforms environments to boot config objects', () => {
-			const bootConfig = configUtils.envToBootConfig(rpiBackend, {
+			const bootConfig = configUtils.envToBootConfig(configTxtBackend, {
 				HOST_CONFIG_initramfs: 'initramf.gz 0x00800000',
 				HOST_CONFIG_dtparam: '"i2c=on","audio=on"',
 				HOST_CONFIG_dtoverlay:

--- a/test/17-config-utils.spec.ts
+++ b/test/17-config-utils.spec.ts
@@ -1,25 +1,124 @@
-import { expect } from './lib/chai-config';
-import * as configUtils from '../src/config/utils';
-import { ConfigTxt } from '../src/config/backends/config-txt';
+import { stub } from 'sinon';
+import * as _ from 'lodash';
 
-const configTxtBackend = new ConfigTxt();
+import { expect } from './lib/chai-config';
+import * as config from '../src/config';
+import { validKeys } from '../src/device-config';
+import * as configUtils from '../src/config/utils';
+import { ExtraUEnv } from '../src/config/backends/extra-uEnv';
+import { Extlinux } from '../src/config/backends/extlinux';
+import { ConfigTxt } from '../src/config/backends/config-txt';
+import { ConfigFs } from '../src/config/backends/config-fs';
+import { ConfigBackend } from '../src/config/backends/backend';
 
 describe('Config Utilities', () => {
-	describe('Boot config', () => {
-		it('correctly transforms environments to boot config objects', () => {
-			const bootConfig = configUtils.envToBootConfig(configTxtBackend, {
-				HOST_CONFIG_initramfs: 'initramf.gz 0x00800000',
-				HOST_CONFIG_dtparam: '"i2c=on","audio=on"',
-				HOST_CONFIG_dtoverlay:
-					'"ads7846","lirc-rpi,gpio_out_pin=17,gpio_in_pin=13"',
-				HOST_CONFIG_foobar: 'baz',
-			});
-			expect(bootConfig).to.deep.equal({
-				initramfs: 'initramf.gz 0x00800000',
-				dtparam: ['i2c=on', 'audio=on'],
-				dtoverlay: ['ads7846', 'lirc-rpi,gpio_out_pin=17,gpio_in_pin=13'],
-				foobar: 'baz',
-			});
+	it('gets list of supported backends', async () => {
+		// Stub so that we get an array containing only config-txt backend
+		const configStub = stub(config, 'get').resolves('raspberry');
+		// Get list of backends
+		const devices = await configUtils.getSupportedBackends();
+		expect(devices.length).to.equal(1);
+		expect(devices[0].constructor.name).to.equal('ConfigTxt');
+		// Restore stub
+		configStub.restore();
+		// TO-DO: When we have a device that will match for multiple backends
+		// add a test that we get more then 1 backend for that device
+	});
+
+	it('transforms environment variables to boot configs', () => {
+		_.forEach(CONFIGS, (configObj: any, key: string) => {
+			expect(
+				configUtils.envToBootConfig(BACKENDS[key], configObj.envVars),
+			).to.deep.equal(configObj.bootConfig);
+		});
+	});
+
+	it('transforms boot configs to environment variables', () => {
+		_.forEach(CONFIGS, (configObj: any, key: string) => {
+			expect(
+				configUtils.bootConfigToEnv(BACKENDS[key], configObj.bootConfig),
+			).to.deep.equal(configObj.envVars);
+		});
+	});
+
+	it('formats keys from config', () => {
+		// Pick any backend to use for test
+		// note: some of the values used will be specific to this backend
+		const backend = BACKENDS['extlinux'];
+		const formattedKeys = configUtils.formatConfigKeys(backend, validKeys, {
+			FOO: 'bar',
+			BAR: 'baz',
+			RESIN_HOST_CONFIG_foo: 'foobaz',
+			BALENA_HOST_CONFIG_foo: 'foobar',
+			RESIN_HOST_CONFIG_other: 'val',
+			BALENA_HOST_CONFIG_baz: 'bad',
+			BALENA_SUPERVISOR_POLL_INTERVAL: '100', // any device
+			BALENA_HOST_EXTLINUX_isolcpus: '1,2,3', // specific to backend
+			RESIN_HOST_EXTLINUX_fdt: '/boot/mycustomdtb.dtb', // specific to backend
+		});
+		expect(formattedKeys).to.deep.equal({
+			HOST_EXTLINUX_isolcpus: '1,2,3',
+			HOST_EXTLINUX_fdt: '/boot/mycustomdtb.dtb',
+			SUPERVISOR_POLL_INTERVAL: '100',
 		});
 	});
 });
+
+const BACKENDS: Record<string, ConfigBackend> = {
+	extraUEnv: new ExtraUEnv(),
+	extlinux: new Extlinux(),
+	configtxt: new ConfigTxt(),
+	configfs: new ConfigFs(),
+};
+
+const CONFIGS = {
+	extraUEnv: {
+		envVars: {
+			HOST_EXTLINUX_fdt: '/boot/mycustomdtb.dtb',
+			HOST_EXTLINUX_isolcpus: '1,2,3',
+			HOST_EXTLINUX_rootwait: '',
+		},
+		bootConfig: {
+			fdt: '/boot/mycustomdtb.dtb',
+			isolcpus: '1,2,3',
+			rootwait: '',
+		},
+	},
+	extlinux: {
+		envVars: {
+			HOST_EXTLINUX_fdt: '/boot/mycustomdtb.dtb',
+			HOST_EXTLINUX_isolcpus: '1,2,3',
+			HOST_EXTLINUX_rootwait: '',
+		},
+		bootConfig: {
+			fdt: '/boot/mycustomdtb.dtb',
+			isolcpus: '1,2,3',
+			rootwait: '',
+		},
+	},
+	configtxt: {
+		envVars: {
+			HOST_CONFIG_initramfs: 'initramf.gz 0x00800000',
+			HOST_CONFIG_dtparam: '"i2c=on","audio=on"',
+			HOST_CONFIG_dtoverlay:
+				'"ads7846","lirc-rpi,gpio_out_pin=17,gpio_in_pin=13"',
+			HOST_CONFIG_foobar: 'baz',
+		},
+		bootConfig: {
+			initramfs: 'initramf.gz 0x00800000',
+			dtparam: ['i2c=on', 'audio=on'],
+			dtoverlay: ['ads7846', 'lirc-rpi,gpio_out_pin=17,gpio_in_pin=13'],
+			foobar: 'baz',
+		},
+	},
+	// TO-DO: Config-FS is commented out because it behaves differently and doesn't
+	// add value to the Config Utilities if we make it work but would like to add it
+	// configfs: {
+	// 	envVars: {
+	// 		ssdt: 'spidev1,1'
+	// 	},
+	// 	bootConfig: {
+	// 		ssdt: ['spidev1,1']
+	// 	},
+	// },
+};

--- a/test/27-extlinux-config.spec.ts
+++ b/test/27-extlinux-config.spec.ts
@@ -4,10 +4,10 @@ import { SinonStub, stub } from 'sinon';
 
 import { expect } from './lib/chai-config';
 import * as fsUtils from '../src/lib/fs-utils';
-import { ExtlinuxConfigBackend } from '../src/config/backends/extlinux';
+import { Extlinux } from '../src/config/backends/extlinux';
 
 describe('Extlinux Configuration', () => {
-	const backend = new ExtlinuxConfigBackend();
+	const backend = new Extlinux();
 
 	it('should parse a extlinux.conf file', () => {
 		const text = stripIndent`\
@@ -24,7 +24,7 @@ describe('Extlinux Configuration', () => {
 		`;
 
 		// @ts-ignore accessing private method
-		const parsed = ExtlinuxConfigBackend.parseExtlinuxFile(text);
+		const parsed = Extlinux.parseExtlinuxFile(text);
 		expect(parsed.globals).to.have.property('DEFAULT').that.equals('primary');
 		expect(parsed.globals).to.have.property('TIMEOUT').that.equals('30');
 		expect(parsed.globals)
@@ -61,7 +61,7 @@ describe('Extlinux Configuration', () => {
 		`;
 
 		// @ts-ignore accessing private method
-		const parsed = ExtlinuxConfigBackend.parseExtlinuxFile(text);
+		const parsed = Extlinux.parseExtlinuxFile(text);
 		expect(parsed.labels).to.have.property('primary').that.deep.equals({
 			LINUX: 'test1',
 			FDT: '/boot/mycustomdtb.dtb',

--- a/test/32-extra-uenv-config.spec.ts
+++ b/test/32-extra-uenv-config.spec.ts
@@ -5,10 +5,10 @@ import { SinonStub, spy, stub } from 'sinon';
 import { expect } from './lib/chai-config';
 import * as fsUtils from '../src/lib/fs-utils';
 import Log from '../src/lib/supervisor-console';
-import { ExtraUEnvConfigBackend } from '../src/config/backends/extra-uEnv';
+import { ExtraUEnv } from '../src/config/backends/extra-uEnv';
 
 describe('extra_uEnv Configuration', () => {
-	const backend = new ExtraUEnvConfigBackend();
+	const backend = new ExtraUEnv();
 	let readFileStub: SinonStub;
 
 	beforeEach(() => {
@@ -25,7 +25,7 @@ describe('extra_uEnv Configuration', () => {
       extra_os_cmdline=isolcpus=3,4 splash console=tty0
 		`;
 		// @ts-ignore accessing private method
-		const parsed = ExtraUEnvConfigBackend.parseOptions(fileContents);
+		const parsed = ExtraUEnv.parseOptions(fileContents);
 		expect(parsed).to.deep.equal({
 			fdt: 'mycustom.dtb',
 			isolcpus: '3,4',
@@ -138,10 +138,10 @@ describe('extra_uEnv Configuration', () => {
 		const logWarningStub = spy(Log, 'warn');
 
 		// @ts-ignore accessing private value
-		const previousSupportedConfigs = ExtraUEnvConfigBackend.supportedConfigs;
+		const previousSupportedConfigs = ExtraUEnv.supportedConfigs;
 		// Stub isSupportedConfig so we can confirm collections work
 		// @ts-ignore accessing private value
-		ExtraUEnvConfigBackend.supportedConfigs = {
+		ExtraUEnv.supportedConfigs = {
 			fdt: { key: 'custom_fdt_file', collection: false },
 			isolcpus: { key: 'extra_os_cmdline', collection: true },
 			console: { key: 'extra_os_cmdline', collection: true },
@@ -166,7 +166,7 @@ describe('extra_uEnv Configuration', () => {
 		(child_process.exec as SinonStub).restore();
 		logWarningStub.restore();
 		// @ts-ignore accessing private value
-		ExtraUEnvConfigBackend.supportedConfigs = previousSupportedConfigs;
+		ExtraUEnv.supportedConfigs = previousSupportedConfigs;
 	});
 
 	it('only allows supported configuration options', () => {


### PR DESCRIPTION
As a part of implementing https://github.com/balena-io/balena-supervisor/issues/1206 it was beneficial/required to apply more then just 1 configuration backend. For example, with this change devices can now match with Extlinux and Config.txt if there was a device that needed this. I plan to leverage this functionality to allow Jetson device to configure Extra_uEnv for setting FDT and a new backend for setting ODMDATA. 

This PR also contains some styling changes to the naming of classes.