### PR TITLE
bug: Allow DNS through firewall for local containers

### DIFF
--- a/src/lib/firewall.ts
+++ b/src/lib/firewall.ts
@@ -56,6 +56,13 @@ const standardServices: iptables.Rule[] = [
 		proto: 'icmp',
 		target: 'ACCEPT',
 	},
+	{
+		comment: 'DNS',
+		action: iptables.RuleAction.Append,
+		proto: 'udp',
+		matches: ['--dport 53', '-i balena0'],
+		target: 'ACCEPT',
+	},
 ];
 
 const standardPolicy: iptables.Rule[] = [

--- a/test/29-firewall.spec.ts
+++ b/test/29-firewall.spec.ts
@@ -278,6 +278,28 @@ describe('Host Firewall', function () {
 		});
 	});
 
+	describe('Service rules', () => {
+		it('should have a rule to allow DNS traffic from the balena0 interface', async () => {
+			await iptablesMock.whilstMocked(
+				async ({ hasAppliedRules, expectRule }) => {
+					// set the firewall to be in auto mode...
+					await config.set({ firewallMode: 'on' });
+					await hasAppliedRules;
+
+					// expect that we have a rule to allow DNS access...
+					expectRule({
+						action: RuleAction.Append,
+						target: 'ACCEPT',
+						chain: 'BALENA-FIREWALL',
+						family: 4,
+						proto: 'udp',
+						matches: ['--dport 53', '-i balena0'],
+					});
+				},
+			);
+		});
+	});
+
 	describe('Supervisor API access', () => {
 		it('should allow access in localmode', async function () {
 			await iptablesMock.whilstMocked(


### PR DESCRIPTION
We provide a local DNS server for containers to use and this
was not allowed through the firewall when enabled.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>