### PR TITLE
Preventing removing all configurations if device has no backends

### DIFF
--- a/src/api-binder.ts
+++ b/src/api-binder.ts
@@ -447,9 +447,7 @@ export class APIBinder {
 		const defaultConfig = deviceConfig.getDefaults();
 
 		const currentState = await this.deviceState.getCurrentForComparison();
-		const targetConfig = await deviceConfig.formatConfigKeys(
-			targetConfigUnformatted,
-		);
+		const targetConfig = deviceConfig.formatConfigKeys(targetConfigUnformatted);
 
 		if (!currentState.local.config) {
 			throw new InternalInconsistencyError(

--- a/src/config/backends/index.ts
+++ b/src/config/backends/index.ts
@@ -1,11 +1,17 @@
+import * as _ from 'lodash';
+
 import { Extlinux } from './extlinux';
 import { ExtraUEnv } from './extra-uEnv';
 import { ConfigTxt } from './config-txt';
 import { ConfigFs } from './config-fs';
 
-export default [
+export const allBackends = [
 	new Extlinux(),
 	new ExtraUEnv(),
 	new ConfigTxt(),
 	new ConfigFs(),
 ];
+
+export function matchesAnyBootConfig(envVar: string): boolean {
+	return allBackends.some((a) => a.isBootConfigVar(envVar));
+}

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -5,7 +5,7 @@ import * as config from '../config';
 import * as constants from '../lib/constants';
 import { getMetaOSRelease } from '../lib/os-release';
 import { EnvVarObject } from '../lib/types';
-import Backends from './backends';
+import { allBackends as Backends } from './backends';
 import { ConfigOptions, ConfigBackend } from './backends/backend';
 
 export async function getSupportedBackends(): Promise<ConfigBackend[]> {
@@ -51,37 +51,7 @@ export function bootConfigToEnv(
 		.value();
 }
 
-export function formatConfigKeys(
-	configBackend: ConfigBackend | null,
-	allowedKeys: string[],
-	conf: { [key: string]: any },
-): { [key: string]: any } {
-	const isConfigType = configBackend != null;
-	const namespaceRegex = /^BALENA_(.*)/;
-	const legacyNamespaceRegex = /^RESIN_(.*)/;
-	const confFromNamespace = filterNamespaceFromConfig(namespaceRegex, conf);
-	const confFromLegacyNamespace = filterNamespaceFromConfig(
-		legacyNamespaceRegex,
-		conf,
-	);
-	const noNamespaceConf = _.pickBy(conf, (_v, k) => {
-		return !_.startsWith(k, 'RESIN_') && !_.startsWith(k, 'BALENA_');
-	});
-	const confWithoutNamespace = _.defaults(
-		confFromNamespace,
-		confFromLegacyNamespace,
-		noNamespaceConf,
-	);
-
-	return _.pickBy(confWithoutNamespace, (_v, k) => {
-		return (
-			_.includes(allowedKeys, k) ||
-			(isConfigType && configBackend!.isBootConfigVar(k))
-		);
-	});
-}
-
-function filterNamespaceFromConfig(
+export function filterNamespaceFromConfig(
 	namespace: RegExp,
 	conf: { [key: string]: any },
 ): { [key: string]: any } {

--- a/src/device-state/preload.ts
+++ b/src/device-state/preload.ts
@@ -80,9 +80,7 @@ export async function loadTargetFromFile(
 		}
 
 		const deviceConf = await deviceConfig.getCurrent();
-		const formattedConf = await deviceConfig.formatConfigKeys(
-			preloadState.config,
-		);
+		const formattedConf = deviceConfig.formatConfigKeys(preloadState.config);
 		preloadState.config = { ...formattedConf, ...deviceConf };
 		const localState = {
 			local: { name: '', ...preloadState },

--- a/test/13-device-config.spec.ts
+++ b/test/13-device-config.spec.ts
@@ -168,19 +168,22 @@ describe('Device Backend Config', () => {
 	it('accepts RESIN_ and BALENA_ variables', async () => {
 		return expect(
 			deviceConfig.formatConfigKeys({
-				FOO: 'bar',
-				BAR: 'baz',
-				RESIN_HOST_CONFIG_foo: 'foobaz',
-				BALENA_HOST_CONFIG_foo: 'foobar',
-				RESIN_HOST_CONFIG_other: 'val',
-				BALENA_HOST_CONFIG_baz: 'bad',
-				BALENA_SUPERVISOR_POLL_INTERVAL: '100',
+				FOO: 'bar', // should be removed
+				BAR: 'baz', // should be removed
+				RESIN_SUPERVISOR_LOCAL_MODE: 'false', // any device
+				BALENA_SUPERVISOR_OVERRIDE_LOCK: 'false', // any device
+				BALENA_SUPERVISOR_POLL_INTERVAL: '100', // any device
+				RESIN_HOST_CONFIG_dtparam: 'i2c_arm=on","spi=on","audio=on', // config.txt backend
+				RESIN_HOST_CONFIGFS_ssdt: 'spidev1.0', // configfs backend
+				BALENA_HOST_EXTLINUX_isolcpus: '1,2,3', // extlinux backend
 			}),
-		).to.eventually.deep.equal({
-			HOST_CONFIG_foo: 'foobar',
-			HOST_CONFIG_other: 'val',
-			HOST_CONFIG_baz: 'bad',
+		).to.deep.equal({
+			SUPERVISOR_LOCAL_MODE: 'false',
+			SUPERVISOR_OVERRIDE_LOCK: 'false',
 			SUPERVISOR_POLL_INTERVAL: '100',
+			HOST_CONFIG_dtparam: 'i2c_arm=on","spi=on","audio=on',
+			HOST_CONFIGFS_ssdt: 'spidev1.0',
+			HOST_EXTLINUX_isolcpus: '1,2,3',
 		});
 	});
 

--- a/test/17-config-utils.spec.ts
+++ b/test/17-config-utils.spec.ts
@@ -3,7 +3,6 @@ import * as _ from 'lodash';
 
 import { expect } from './lib/chai-config';
 import * as config from '../src/config';
-import { validKeys } from '../src/device-config';
 import * as configUtils from '../src/config/utils';
 import { ExtraUEnv } from '../src/config/backends/extra-uEnv';
 import { Extlinux } from '../src/config/backends/extlinux';
@@ -38,28 +37,6 @@ describe('Config Utilities', () => {
 			expect(
 				configUtils.bootConfigToEnv(BACKENDS[key], configObj.bootConfig),
 			).to.deep.equal(configObj.envVars);
-		});
-	});
-
-	it('formats keys from config', () => {
-		// Pick any backend to use for test
-		// note: some of the values used will be specific to this backend
-		const backend = BACKENDS['extlinux'];
-		const formattedKeys = configUtils.formatConfigKeys(backend, validKeys, {
-			FOO: 'bar',
-			BAR: 'baz',
-			RESIN_HOST_CONFIG_foo: 'foobaz',
-			BALENA_HOST_CONFIG_foo: 'foobar',
-			RESIN_HOST_CONFIG_other: 'val',
-			BALENA_HOST_CONFIG_baz: 'bad',
-			BALENA_SUPERVISOR_POLL_INTERVAL: '100', // any device
-			BALENA_HOST_EXTLINUX_isolcpus: '1,2,3', // specific to backend
-			RESIN_HOST_EXTLINUX_fdt: '/boot/mycustomdtb.dtb', // specific to backend
-		});
-		expect(formattedKeys).to.deep.equal({
-			HOST_EXTLINUX_isolcpus: '1,2,3',
-			HOST_EXTLINUX_fdt: '/boot/mycustomdtb.dtb',
-			SUPERVISOR_POLL_INTERVAL: '100',
 		});
 	});
 });


### PR DESCRIPTION
**Problem:** 

When https://github.com/balena-io/balena-supervisor/pull/1431 was merged it introduced a regression that would make devices ignore all their configurations set in the dashboard such as firewall, localmode, etc. The cause of this issue was because in the following code we iterate over the list of matched backends and run [configUtils.formatConfigKeys](https://github.com/balena-io/balena-supervisor/blob/61811dd27a083ecff7ec83e88d019c205a8295a0/src/config/utils.ts#L54) with the backend as the first parameter.

https://github.com/balena-io/balena-supervisor/blob/61811dd27a083ecff7ec83e88d019c205a8295a0/src/device-config.ts#L301-L313

When the PR that introduced this regression was written I had gotten the impression that this function should only run if you have a backend otherwise return an empty config object. However, that function formats all configuration options even if a null backend is passed. So when you don't have a backend that function still needs to run to return the configs for firewall, localmode, etc.

**Solution:**

This PR resolves this issue by always running formatConfigKeys and modifying the original logic of "does this configVar match this backend" and instead try to match that configVar on any backend. The previous logic worked because the device only used 1 backend to configure at a time but now we allow multiple backends to configure and so matching the configVar must be applied to all backends and if any returns true then it is valid. We also gain the benefit of no longer having any async IO operations when running this code path. In addition this PR also optimizes that fact that each backend matched would format the same vars multiple times and so this only formats the variables once.

----

Closes: #1437
Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>