### PR TITLE
Add features label `io.balena.features.journal-logs`

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -328,6 +328,11 @@ export async function addFeaturesFromLabels(
 	};
 
 	const features = {
+		'io.balena.features.journal-logs': () => {
+			service.config.volumes.push('/var/log/journal:/var/log/journal:ro');
+			service.config.volumes.push('/run/log/journal:/run/log/journal:ro');
+			service.config.volumes.push('/etc/machine-id:/etc/machine-id:ro');
+		},
 		'io.balena.features.dbus': () =>
 			service.config.volumes.push('/run/dbus:/host/run/dbus'),
 		'io.balena.features.kernel-modules': () =>


### PR DESCRIPTION
Adds new label `io.balena.features.journal-logs` to mount the directories required to read journal.

Tested `promtail` in a container with this label was able to read the journal files, it uses `sd-journal` C API via go to read the files https://www.freedesktop.org/software/systemd/man/sd-journal.html

Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>