### PR TITLE
Revert "Don't enforce the vc4-fkms-v3d dtoverlay on rpi4"

### DIFF
--- a/src/device-config.ts
+++ b/src/device-config.ts
@@ -612,8 +612,13 @@ function checkBoolChanged(
 // Modifies conf
 // exported for tests
 export function ensureRequiredOverlay(deviceType: string, conf: ConfigOptions) {
-	if (deviceType === 'fincm3') {
-		ensureDtoverlay(conf, 'balena-fin');
+	switch (deviceType) {
+		case 'fincm3':
+			ensureDtoverlay(conf, 'balena-fin');
+			break;
+		case 'raspberrypi4-64':
+			ensureDtoverlay(conf, 'vc4-fkms-v3d');
+			break;
 	}
 
 	return conf;

--- a/test/13-device-config.spec.ts
+++ b/test/13-device-config.spec.ts
@@ -310,6 +310,65 @@ describe('Device Backend Config', () => {
 		});
 	});
 
+	describe('Raspberry pi4', () => {
+		it('should always add the vc4-fkms-v3d dtoverlay', () => {
+			expect(
+				deviceConfig.ensureRequiredOverlay('raspberrypi4-64', {}),
+			).to.deep.equal({
+				dtoverlay: ['vc4-fkms-v3d'],
+			});
+			expect(
+				deviceConfig.ensureRequiredOverlay('raspberrypi4-64', {
+					test: '123',
+					test2: ['123'],
+					test3: ['123', '234'],
+				}),
+			).to.deep.equal({
+				test: '123',
+				test2: ['123'],
+				test3: ['123', '234'],
+				dtoverlay: ['vc4-fkms-v3d'],
+			});
+			expect(
+				deviceConfig.ensureRequiredOverlay('raspberrypi4-64', {
+					dtoverlay: 'test',
+				}),
+			).to.deep.equal({ dtoverlay: ['test', 'vc4-fkms-v3d'] });
+			expect(
+				deviceConfig.ensureRequiredOverlay('raspberrypi4-64', {
+					dtoverlay: ['test'],
+				}),
+			).to.deep.equal({ dtoverlay: ['test', 'vc4-fkms-v3d'] });
+		});
+
+		it('should not cause a config change when the cloud does not specify the pi4 overlay', () => {
+			expect(
+				deviceConfig.bootConfigChangeRequired(
+					configTxtBackend,
+					{ HOST_CONFIG_dtoverlay: '"test","vc4-fkms-v3d"' },
+					{ HOST_CONFIG_dtoverlay: '"test"' },
+					'raspberrypi4-64',
+				),
+			).to.equal(false);
+			expect(
+				deviceConfig.bootConfigChangeRequired(
+					configTxtBackend,
+					{ HOST_CONFIG_dtoverlay: '"test","vc4-fkms-v3d"' },
+					{ HOST_CONFIG_dtoverlay: 'test' },
+					'raspberrypi4-64',
+				),
+			).to.equal(false);
+			expect(
+				deviceConfig.bootConfigChangeRequired(
+					configTxtBackend,
+					{ HOST_CONFIG_dtoverlay: '"test","test2","vc4-fkms-v3d"' },
+					{ HOST_CONFIG_dtoverlay: '"test","test2"' },
+					'raspberrypi4-64',
+				),
+			).to.equal(false);
+		});
+	});
+
 	// describe('ConfigFS', () => {
 	// 	const upboardConfig = new DeviceConfig();
 	// 	let upboardConfigBackend: ConfigBackend | null;


### PR DESCRIPTION
This was fixed in balenaOS 2.44.0+rev9

This reverts commit de4c1b25385630b6f9fadb7a362d5556c2cc5008.
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>