### PR TITLE
Correctly evaluate if scheduledApply.delay is not set

### DIFF
--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -854,7 +854,10 @@ export function triggerApplyTarget({
 			// If a delay has been set it's because we need to hold off before applying again,
 			// so we need to respect the maximum delay that has
 			// been passed
-			if (!scheduledApply.delay) {
+			if (scheduledApply.delay === undefined || isNaN(scheduledApply.delay)) {
+				log.debug(
+					`Tried to apply target with invalid delay: ${scheduledApply.delay}`,
+				);
 				throw new InternalInconsistencyError(
 					'No delay specified in scheduledApply',
 				);


### PR DESCRIPTION
[triggerApplyTarget](https://github.com/balena-io/balena-supervisor/blob/fbc2875951afbfe4735e09708b55c90520fc2dbd/src/device-state.ts#L838) function in device-state uses a default value of 0 for a delay. When this value is checked if it is undefined/not set the condition can fail given the default value. This PR checks if the value is undefined or not a number rather then if it's falsey.

Closes: #1428
Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>