### PR TITLE
Fix config checks for ConfigFS backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ tools/dind/config/
 tools/dind/config.json*
 tools/dind/apps.json
 tools/dind/backup.tgz
-test/data/config*.json
+test/data/**/config*.json
 test/data/*.sqlite
 test/data/led_file
 /coverage/

--- a/src/config/backends/config-fs.ts
+++ b/src/config/backends/config-fs.ts
@@ -94,7 +94,7 @@ export class ConfigFs extends ConfigBackend {
 				`AML: ${oemId.trim()} ${oemTableId.trim()} (Rev ${oemRevision.trim()})`,
 			);
 		} catch (e) {
-			log.error('Issue while loading AML ${aml}', e);
+			log.error(`Issue while loading AML ${aml}`, e);
 		}
 		return true;
 	}
@@ -214,7 +214,7 @@ export class ConfigFs extends ConfigBackend {
 					return [value];
 				} else {
 					// or, it could be parsable as the content of a JSON array; "value" | "value1","value2"
-					return value.split(',').map((v) => v.replace('"', '').trim());
+					return value.split(',').map((v) => v.replace(/"/g, '').trim());
 				}
 			default:
 				return value;


### PR DESCRIPTION
When trying to apply SSDT overlays in Up Board, the supervisor currently
gets stuck in a loop trying to apply target state. See #1465

This was due to a bug in parsing the configuration, which lead to
the method bootConfigChangeRequired returning true when no change was
needed.

Change-type: patch
Signed-off-by: Felipe Lalanne <felipe@balena.io>
Connects-to: #1465