### PR TITLE
Fix supervisor deadlock during migration

### DIFF
--- a/src/migrations/M00005.js
+++ b/src/migrations/M00005.js
@@ -1,5 +1,3 @@
-import { generateScopedKey } from '../lib/api-keys';
-
 export async function up(knex) {
 	// Create a new table to hold the api keys
 	await knex.schema.createTable('apiSecret', (table) => {
@@ -13,18 +11,6 @@ export async function up(knex) {
 
 	// Delete any existing API secrets
 	await knex('config').where({ key: 'apiSecret' }).del();
-
-	// Add an api secret per service in the db
-	const apps = await knex('app');
-
-	for (const app of apps) {
-		const appId = app.appId;
-		const services = JSON.parse(app.services);
-		for (const service of services) {
-			const serviceId = service.id;
-			await generateScopedKey(appId, serviceId);
-		}
-	}
 }
 
 export function down() {


### PR DESCRIPTION
Due to the singleton work, when performing migration M00005 and there
are apps with services created in the database, a deadlock occurs
during database initialization due to a circular
dependency for generating scoped keys.

Change-type: patch
Signed-off-by: Felipe Lalanne <felipe@balena.io>
Connects-to: #1468