### PR TITLE
log networks that do not match

### DIFF
--- a/src/compose/service.ts
+++ b/src/compose/service.ts
@@ -742,6 +742,15 @@ export class Service {
 			}
 			sameNetworks =
 				sameNetworks && this.isSameNetwork(this.config.networks[name], network);
+			if (!sameNetworks) {
+				const currentNetwork = this.config.networks[name];
+				const newNetwork = network;
+				log.debug(
+					`Networks do not match!\nCurrent network: \n${JSON.stringify(
+						currentNetwork,
+					)}\nNew network: \n${JSON.stringify(newNetwork)}`,
+				);
+			}
 		});
 
 		// Check the configuration for any changes


### PR DESCRIPTION
In a few instances users are unclear why their services are restarted because the SV only logs "Network changes detected". This makes it really challenging to know where to look next. This PR aims to show what networks changes have triggered their services to restart.