### PR TITLE
Add the 'io.balena.features.early-run' label to bind mount the early /run filesystem

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -383,6 +383,8 @@ export async function addFeaturesFromLabels(
 			);
 		},
 		'io.balena.features.sysfs': () => service.config.volumes.push('/sys:/sys'),
+		'io.balena.features.early-run': () =>
+			service.config.volumes.push('/run:/run'),
 		'io.balena.features.procfs': () =>
 			service.config.volumes.push('/proc:/proc'),
 		'io.balena.features.gpu': () =>


### PR DESCRIPTION
Some daemons (such udev or systemd) use the early stage `/run` filesystem for runtime data. This label makes the supervisor mount the host `/run` folder on the `/run` folder of the container

Change-type: minor
Signed-off-by: Tomás Tormo <tomast@balena.io>