### PR TITLE
Attempt a state report once every maxReportFrequency

### DIFF
--- a/src/device-state/current-state.ts
+++ b/src/device-state/current-state.ts
@@ -243,12 +243,16 @@ const reportCurrentState = (): null => {
 };
 
 export const startReporting = () => {
-	deviceState.on('change', () => {
+	const doReport = () => {
 		if (!reportPending) {
-			// A latency of 100ms should be acceptable and
-			// allows avoiding catching docker at weird states
 			reportCurrentState();
 		}
-	});
+	};
+
+	// If the state changes, report it
+	deviceState.on('change', doReport);
+	// But check once every max report frequency to ensure that changes in system
+	// info are picked up (CPU temp etc)
+	setInterval(doReport, constants.maxReportFrequency);
 	return reportCurrentState();
 };


### PR DESCRIPTION
 With the addition of the system information feature (CPU temp) etc if
 there wasn't any changes in the docker or config state of the device,
 updates in system information would not be sent to the API. Now we
 attempt to send data once every maxReportFrequency (although this does
 not mean that we will be sending data that often, we still only send the
 delta, if one exists)

We also remove superfluous functions in api-binder, which were re-introduced as part of a rebase.

 Change-type: patch
 Closes: #1481
 Signed-off-by: Cameron Diver <cameron@balena.io>
