### PR TITLE
Improve calculation for used system memory

### DIFF
--- a/src/lib/system-info.ts
+++ b/src/lib/system-info.ts
@@ -62,7 +62,7 @@ export async function getMemoryInformation(): Promise<{
 }> {
 	const mem = await systeminformation.mem();
 	return {
-		used: bytesToMb(mem.used),
+		used: bytesToMb(mem.used - mem.cached - mem.buffers),
 		total: bytesToMb(mem.total),
 	};
 }

--- a/test/38-sys-info.spec.ts
+++ b/test/38-sys-info.spec.ts
@@ -1,6 +1,17 @@
 import { expect } from 'chai';
 import * as sysInfo from '../src/lib/system-info';
 
+import { SinonStub, stub } from 'sinon';
+import * as systeminformation from 'systeminformation';
+
+function toMb(bytes: number) {
+	return Math.floor(bytes / 1024 / 1024);
+}
+
+function toBytes(kb: number) {
+	return kb * 1024;
+}
+
 describe('System information', () => {
 	describe('Delta-based filtering', () => {
 		it('should correctly filter cpu usage', () => {
@@ -53,6 +64,42 @@ describe('System information', () => {
 					cpu_temp: 5,
 				} as sysInfo.SystemInfo),
 			).to.deep.equal([]);
+		});
+	});
+
+	describe('Memory information', function () {
+		it('should return the correct value for memory usage', async () => {
+			const [total, free, cached, buffers] = [
+				763472,
+				143896,
+				368360,
+				16724,
+			].map(toBytes);
+
+			// Stub the output of the systeminformation module
+			stub(systeminformation, 'mem').resolves({
+				total,
+				free,
+				used: total - free,
+				cached,
+				buffers,
+				slab: 0,
+				buffcache: 0,
+				available: 0,
+				active: 0,
+				swaptotal: 0,
+				swapfree: 0,
+				swapused: 0,
+			});
+
+			const meminfo = await sysInfo.getMemoryInformation();
+			expect(meminfo.total).to.be.equal(toMb(total));
+
+			// used memory = total - free - (cached + buffers)
+			// this is how `htop` and `free` calculate it
+			expect(meminfo.used).to.be.equal(toMb(total - free - (cached + buffers)));
+
+			(systeminformation.mem as SinonStub).restore();
 		});
 	});
 });


### PR DESCRIPTION
The memory information reported by the supervisor currently
estimates the value of used memory as `MemTotal - MemFree`.
However, linux systems will try to cache and buffer as much
memory as possible, which will affect the output of `MemFree`
(from /proc/meminfo) and in consequence the memory usage seen
by the user on the dashboard, which will appear much greater than
it is.

The correct calculation should be `MemTotal - MemFree - Buffers - Cached`,
which the calculation performed by `htop` and the `free` commands.

Change-type: patch
Signed-off-by: Felipe Lalanne <felipe@balena.io>
Connects-to: #1471