### PR TITLE
Change log source from docker to journalctl

### DIFF
--- a/src/compose/service-manager.ts
+++ b/src/compose/service-manager.ts
@@ -24,6 +24,7 @@ import { Service } from './service';
 import { serviceNetworksToDockerNetworks } from './utils';
 
 import log from '../lib/supervisor-console';
+import logMonitor from '../logging/monitor';
 
 interface ServiceManagerEvents {
 	change: void;
@@ -383,7 +384,7 @@ export function listenToEvents() {
 		parser.on('data', async (data: { status: string; id: string }) => {
 			if (data != null) {
 				const status = data.status;
-				if (status === 'die' || status === 'start') {
+				if (status === 'die' || status === 'start' || status === 'destroy') {
 					try {
 						let service: Service | null = null;
 						try {
@@ -415,6 +416,8 @@ export function listenToEvents() {
 									serviceId,
 									imageId,
 								});
+							} else if (status === 'destroy') {
+								await logMonitor.detach(data.id);
 							}
 						}
 					} catch (e) {

--- a/src/lib/journald.ts
+++ b/src/lib/journald.ts
@@ -6,10 +6,12 @@ import log from './supervisor-console';
 export function spawnJournalctl(opts: {
 	all: boolean;
 	follow: boolean;
-	count?: number;
+	count?: number | 'all';
 	unit?: string;
 	containerId?: string;
 	format: string;
+	filterString?: string;
+	since?: number;
 }): ChildProcess {
 	const args = [
 		// The directory we want to run the chroot from
@@ -34,8 +36,21 @@ export function spawnJournalctl(opts: {
 		args.push('-n');
 		args.push(opts.count.toString());
 	}
+	if (opts.since != null) {
+		args.push('-S');
+		args.push(
+			new Date(opts.since)
+				.toISOString()
+				.replace(/T/, ' ') // replace T with a space
+				.replace(/\..+/, ''), // delete the dot and everything after
+		);
+	}
 	args.push('-o');
 	args.push(opts.format);
+
+	if (opts.filterString) {
+		args.push(opts.filterString);
+	}
 
 	log.debug('Spawning journald with: chroot ', args.join(' '));
 

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -14,6 +14,7 @@ import version = require('./lib/supervisor-version');
 
 import * as avahi from './lib/avahi';
 import * as firewall from './lib/firewall';
+import logMonitor from './logging/monitor';
 
 const startupConfigFields: config.ConfigKey[] = [
 	'uuid',
@@ -75,6 +76,8 @@ export class Supervisor {
 		deviceState.on('shutdown', () => this.api.stop());
 
 		await apiBinder.start();
+
+		logMonitor.start();
 	}
 }
 


### PR DESCRIPTION
- `logMonitor.start()` call in supervisor `init`, spawns `journalctl` process to follow all container logs
- `logMonitor.attach()` backfills logs since `lastSentTimestamp` with a new `journalctl` process using `since` argument
- `logMonitor.detach()` is called on docker `destroy` event

Change-type: minor
Signed-off-by: Thomas Manning <thomasm@balena.io>