### PR TITLE
Fixes check allowing preloading in local (unmanaged) mode

### DIFF
--- a/src/device-state.ts
+++ b/src/device-state.ts
@@ -467,7 +467,7 @@ export async function setTarget(target: TargetState, localSource?: boolean) {
 			await config.set({ name: target.local.name }, trx);
 			await deviceConfig.setTarget(target.local.config, trx);
 
-			if (localSource || apiEndpoint == null) {
+			if (localSource || apiEndpoint == null || apiEndpoint === '') {
 				await applicationManager.setTarget(
 					target.local.apps,
 					target.dependent,


### PR DESCRIPTION
**tl;dr** `applicationManager.setTarget` for unmanaged devices in local mode, sets incorrect `source` in the DB, because `apiEndpoint` is resolved to an empty string (not null), which results in preloaded app containers not provisioning due to `source` being set in the else block to an empty string:

```
			if (localSource || apiEndpoint == null || apiEndpoint === '') {
				await applicationManager.setTarget(
					target.local.apps,
					target.dependent,
					'local',
					trx,
				);
			} else {
				...
```

adding `apiEndpoint === ''` to check above, correctly sets the source field, allowing `getTargetApps` to correctly set `targetState`:

```
export async function getTargetApps(): Promise<DatabaseApps> {
	if (targetState == null) {
		const { apiEndpoint, localMode } = await config.getMany([
			'apiEndpoint',
			'localMode',
		]);

                 // source = 'local' in unmanaged/local mode
		const source = localMode ? 'local' : apiEndpoint;
		targetState = await db.models('app').where({ source });
	}
	return targetState!;
}
```


* adds apiEndpoint empty string check

Change-type: patch