### PR TITLE
Mount docker socket under `/host/run` for services

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -345,12 +345,18 @@ export async function addFeaturesFromLabels(
 				: null,
 		'io.balena.features.balena-socket': () => {
 			service.config.volumes.push(
+				`${constants.dockerSocket}:${constants.containerDockerSocket}`,
+			);
+
+			// Maintain the /var/run mount for backwards compatibility
+			service.config.volumes.push(
 				`${constants.dockerSocket}:${constants.dockerSocket}`,
 			);
+
 			if (service.config.environment['DOCKER_HOST'] == null) {
 				service.config.environment[
 					'DOCKER_HOST'
-				] = `unix://${constants.dockerSocket}`;
+				] = `unix://${constants.containerDockerSocket}`;
 			}
 			// We keep balena.sock for backwards compatibility
 			if (constants.dockerSocket !== '/var/run/balena.sock') {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,6 +11,10 @@ const constants = {
 		checkString(process.env.DATABASE_PATH) || '/data/database.sqlite',
 	containerId: checkString(process.env.SUPERVISOR_CONTAINER_ID) || undefined,
 	dockerSocket: process.env.DOCKER_SOCKET || '/var/run/docker.sock',
+
+	// In-container location for docker socket
+	// Mount in /host/run to avoid clashing with systemd
+	containerDockerSocket: '/host/run/balena-engine.sock',
 	supervisorImage:
 		checkString(process.env.SUPERVISOR_IMAGE) || 'resin/rpi-supervisor',
 	ledFile:

--- a/test/04-service.spec.ts
+++ b/test/04-service.spec.ts
@@ -8,6 +8,7 @@ import {
 	ServiceComposeConfig,
 	ServiceConfig,
 } from '../src/compose/types/service';
+import * as constants from '../src/lib/constants';
 
 const configs = {
 	simple: {
@@ -268,6 +269,30 @@ describe('compose/service', () => {
 				'/tmp/balena-supervisor/services/123/test:/tmp/resin',
 				'/tmp/balena-supervisor/services/123/test:/tmp/balena',
 			]);
+	});
+
+	it('should correctly handle io.balena.features.balena-socket label', async () => {
+		const service = await Service.fromComposeObject(
+			{
+				appId: 123456,
+				serviceId: 123456,
+				serviceName: 'foobar',
+				labels: {
+					'io.balena.features.balena-socket': '1',
+				},
+			},
+			{ appName: 'test' } as any,
+		);
+
+		expect(service.config.volumes).to.include.members([
+			`${constants.dockerSocket}:${constants.dockerSocket}`,
+			`${constants.dockerSocket}:/host/run/balena-engine.sock`,
+			`${constants.dockerSocket}:/var/run/balena.sock`,
+		]);
+
+		expect(service.config.environment['DOCKER_HOST']).to.equal(
+			'unix:///host/run/balena-engine.sock',
+		);
 	});
 
 	describe('Ordered array parameters', () => {


### PR DESCRIPTION
Currently, when the label `io.balena.features.balena-socket` is set,
the balena engine socket is mounted under `/run/balena-engine.sock`.

This causes a problem when using systemd inside the container, since
this service remounts `/run` and `/run/lock` as tmpfs, causing the
socket to become unavailable.

Making a mount of the socket into `/host/run` solves this issue. This is
the same approach taken with DBUS.

Change-type: patch
Signed-off-by: Felipe Lalanne <felipe@balena.io>
Connects-to: #1494