### PR TITLE
Allow storing commits against their appIds

### DIFF
--- a/src/compose/app.ts
+++ b/src/compose/app.ts
@@ -168,7 +168,12 @@ export class App {
 			this.commit !== target.commit
 		) {
 			// TODO: The next PR should change this to support multiapp commit values
-			steps.push(generateStep('updateCommit', { target: target.commit }));
+			steps.push(
+				generateStep('updateCommit', {
+					target: target.commit,
+					appId: this.appId,
+				}),
+			);
 		}
 
 		return steps;

--- a/src/compose/commit.ts
+++ b/src/compose/commit.ts
@@ -1,0 +1,32 @@
+import * as db from '../db';
+
+const cache: { [appId: number]: string } = {};
+
+export async function getCommitForApp(
+	appId: number,
+): Promise<string | undefined> {
+	if (cache[appId] != null) {
+		return cache[appId];
+	}
+
+	const commit = await db
+		.models('currentCommit')
+		.where({ appId })
+		.select('commit');
+
+	if (commit?.[0] != null) {
+		cache[appId] = commit[0].commit;
+		return commit[0].commit;
+	}
+
+	return;
+}
+
+export function upsertCommitForApp(
+	appId: number,
+	commit: string,
+	trx?: db.Transaction,
+): Promise<void> {
+	cache[appId] = commit;
+	return db.upsertModel('currentCommit', { commit, appId }, { appId }, trx);
+}

--- a/src/compose/composition-steps.ts
+++ b/src/compose/composition-steps.ts
@@ -14,6 +14,7 @@ import { checkTruthy } from '../lib/validation';
 import * as networkManager from './network-manager';
 import * as volumeManager from './volume-manager';
 import { DeviceReportFields } from '../types/state';
+import * as commitStore from './commit';
 
 interface BaseCompositionStepArgs {
 	force?: boolean;
@@ -62,6 +63,7 @@ interface CompositionStepArgs {
 	} & BaseCompositionStepArgs;
 	updateCommit: {
 		target: string;
+		appId: number;
 	};
 	handover: {
 		current: Service;
@@ -218,7 +220,7 @@ export function getExecutors(app: {
 			app.callbacks.containerStarted(container.id);
 		},
 		updateCommit: async (step) => {
-			await config.set({ currentCommit: step.target });
+			await commitStore.upsertCommitForApp(step.appId, step.target);
 		},
 		handover: (step) => {
 			return app.lockFn(

--- a/src/config/schema-type.ts
+++ b/src/config/schema-type.ts
@@ -150,10 +150,6 @@ export const schemaTypes = {
 		),
 		default: NullOrUndefined,
 	},
-	currentCommit: {
-		type: t.string,
-		default: NullOrUndefined,
-	},
 	targetStateSet: {
 		type: PermissiveBoolean,
 		default: false,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -155,11 +155,6 @@ export const schema = {
 		mutable: true,
 		removeIfNull: false,
 	},
-	currentCommit: {
-		source: 'db',
-		mutable: true,
-		removeIfNull: false,
-	},
 	targetStateSet: {
 		source: 'db',
 		mutable: true,

--- a/src/migrations/M00006.js
+++ b/src/migrations/M00006.js
@@ -1,0 +1,28 @@
+export async function up(knex) {
+	await knex.schema.createTable('currentCommit', (table) => {
+		table.integer('id').primary();
+		table.integer('appId').notNullable();
+		table.string('commit').notNullable();
+		table.unique(['appId']);
+	});
+
+	const currentCommit = await knex('config')
+		.where({ key: 'currentCommit' })
+		.select('value');
+	if (currentCommit[0] != null) {
+		const apps = await knex('app').select(['appId']);
+
+		for (const app of apps) {
+			await knex('currentCommit').insert({
+				appId: app.appId,
+				commit: currentCommit[0].value,
+			});
+		}
+
+		await knex('config').where({ key: 'currentCommit' }).delete();
+	}
+}
+
+export async function down() {
+	throw new Error('Not implemented');
+}

--- a/test/21-supervisor-api.spec.ts
+++ b/test/21-supervisor-api.spec.ts
@@ -237,7 +237,7 @@ describe('SupervisorAPI', () => {
 
 		// TODO: add tests for V1 endpoints
 		describe('GET /v1/apps/:appId', () => {
-			it('returns information about a SPECIFIC application', async () => {
+			it('returns information about a specific application', async () => {
 				await request
 					.get('/v1/apps/2')
 					.set('Accept', 'application/json')

--- a/test/39-compose-commit.spec.ts
+++ b/test/39-compose-commit.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import * as commitStore from '../src/compose/commit';
+import * as db from '../src/db';
+
+describe('compose/commit', () => {
+	before(async () => await db.initialized);
+
+	describe('Fetching commits', () => {
+		beforeEach(async () => {
+			// Clear the commit values in the db
+			await db.models('currentCommit').del();
+		});
+
+		it('should fetch a commit for an appId', async () => {
+			const commit = 'abcdef';
+			await commitStore.upsertCommitForApp(1, commit);
+
+			expect(await commitStore.getCommitForApp(1)).to.equal(commit);
+		});
+
+		it('should fetch the correct commit value when there is multiple commits', async () => {
+			const commit = 'abcdef';
+			await commitStore.upsertCommitForApp(1, '123456');
+			await commitStore.upsertCommitForApp(2, commit);
+
+			expect(await commitStore.getCommitForApp(2)).to.equal(commit);
+		});
+	});
+
+	it('should correctly insert a commit when a commit for the same app already exists', async () => {
+		const commit = 'abcdef';
+		await commitStore.upsertCommitForApp(1, '123456');
+		await commitStore.upsertCommitForApp(1, commit);
+		expect(await commitStore.getCommitForApp(1)).to.equal(commit);
+	});
+});

--- a/test/data/device-api-responses.json
+++ b/test/data/device-api-responses.json
@@ -16,7 +16,7 @@
         "body": {
           "appId": 2,
           "containerId": "abc123",
-          "commit": "7fc9c5bea8e361acd49886fe6cc1e1cd",
+          "commit": "4e380136c2cf56cd64197d51a1ab263a",
           "env": {},
           "releaseId": 77777
         }

--- a/test/lib/mocked-device-api.ts
+++ b/test/lib/mocked-device-api.ts
@@ -6,6 +6,7 @@ import * as applicationManager from '../../src/compose/application-manager';
 import * as networkManager from '../../src/compose/network-manager';
 import * as serviceManager from '../../src/compose/service-manager';
 import * as volumeManager from '../../src/compose/volume-manager';
+import * as commitStore from '../../src/compose/commit';
 import * as config from '../../src/config';
 import * as db from '../../src/db';
 import { createV1Api } from '../../src/device-api/v1';
@@ -17,8 +18,9 @@ import SupervisorAPI from '../../src/supervisor-api';
 const DB_PATH = './test/data/supervisor-api.sqlite';
 // Holds all values used for stubbing
 const STUBBED_VALUES = {
-	config: {
-		currentCommit: '7fc9c5bea8e361acd49886fe6cc1e1cd',
+	commits: {
+		1: '7fc9c5bea8e361acd49886fe6cc1e1cd',
+		2: '4e380136c2cf56cd64197d51a1ab263a',
 	},
 	services: [
 		{
@@ -110,9 +112,9 @@ async function initConfig(): Promise<void> {
 	await config.initialized;
 
 	// Set a currentCommit
-	await config.set({
-		currentCommit: STUBBED_VALUES.config.currentCommit,
-	});
+	for (const [id, commit] of Object.entries(STUBBED_VALUES.commits)) {
+		await commitStore.upsertCommitForApp(parseInt(id, 10), commit);
+	}
 }
 
 function buildRoutes(): Router {


### PR DESCRIPTION
This paves the way for running multiple applications and storing
information related to the application against the application itself. A
couple of hacks have been added to v1 and v2 endpoints to maintain
compatability but these should eventually be removed with the addition
of a v3 api.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>