### PR TITLE
Patched scoped api keys to allow current CLI to use livepush

### DIFF
--- a/src/device-api/v2.ts
+++ b/src/device-api/v2.ts
@@ -510,7 +510,12 @@ export function createV2Api(router: Router) {
 			overallDownloadProgress = downloadProgressTotal / downloads;
 		}
 
-		if (_.uniq(appIds).length > 1) {
+		// TODO: This check is to allow the CLI to continue using livepush
+		// When the CLI passes scoped API keys remove this
+		// We check if the device is in localmode because this is required for livepush
+		const ALLOW_MULTIPLE_APPS = await config.get('localMode');
+
+		if (_.uniq(appIds).length > 1 && !ALLOW_MULTIPLE_APPS) {
 			// We can't accurately return the commit value each app without changing
 			// the shape of the data, and instead we'd like users to use the new v3
 			// endpoints, which will come with multiapp

--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -134,6 +134,8 @@ export const authMiddleware: AuthorizedRequestHandler = async (
 
 		// no need to authenticate, shortcut
 		if (!needsAuth) {
+			// Allow any requests to be scoped by default
+			req.auth.isScoped = () => true;
 			return next();
 		}
 


### PR DESCRIPTION
When the CLI uses livepush to allow for real time development of containers on your device it runs the containers on your device by building them locally but then also via livepush it can magically update your container on device with changes you made on your machine. To do this livepush needs a container Id.

When we added scoped api keys to all the /v2 API endpoints in https://github.com/balena-io/balena-supervisor/commit/c08de8701e49f417d2fc5849d237b9ed69b438e2 we caused the CLI to not be able to get the container Id that it wants to reload. This is because the CLI queries the `/v2/state/status` endpoint and then gets the container by serviceName. Since the CLI does not know about scoped api keys and it doesn't pass any key at all, the API returns an empty container list.

This PR is a patch to allow the current CLI to continue working until it can implement scoped api keys. At which we would then remove this patch.

Closes: #1512
Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>