### PR TITLE
Improve supervisor API behavior when locks are set

### DIFF
--- a/src/lib/update-lock.ts
+++ b/src/lib/update-lock.ts
@@ -64,6 +64,10 @@ function dispose(release: () => void): Bluebird<void> {
 		.return();
 }
 
+/**
+ * Try to take the locks for an application. If force is set, it will remove
+ * all existing lockfiles before performing the operation
+ */
 export function lock(
 	appId: number | null,
 	{ force = false }: { force: boolean },

--- a/test/lib/mocked-device-api.ts
+++ b/test/lib/mocked-device-api.ts
@@ -78,6 +78,12 @@ const mockService = (overrides?: Partial<Service>) => {
 			extraNetworksToJoin: () => {
 				return [];
 			},
+			isEqualConfig: (service: Service) => {
+				return _.isEqual(
+					_.pick(mockService, ['imageId', 'containerId', 'serviceId']),
+					_.pick(service, ['imageId', 'containerId', 'serviceId']),
+				);
+			},
 		},
 		...overrides,
 	} as Service;


### PR DESCRIPTION
This PR adds the following

* Supervisor v1 API application actions now return HTTP status code 423 when locks
  are preventing the action to be performed. Previously this resulted in a
  503 error
* Supervisor API v2 service actions now returns HTTP status code 423 when locks are
  preventing the action to be performed. Previously, this resulted in an
  exception logged by the supervisor and the API query timing out
* Supervisor API `/v2/applications/:appId/start-service` now does not
  check for a lock to allow a crashed service to be restarted. 
Lock handling in v2 service actions is now performed by each step executor
* /v1/apps/:appId/start now queries the target state and uses that
  information to execute the start step (as v2 does). Previously start
  resulted in `cannot get appId from undefined`
* Add tests for API methods

Change-type: patch
Connects-to: #1523
Signed-off-by: Felipe Lalanne <felipe@balena.io>