### PR TITLE
Fix gpu label support

### DIFF
--- a/src/compose/utils.ts
+++ b/src/compose/utils.ts
@@ -402,8 +402,11 @@ export async function addFeaturesFromLabels(
 			// bahavior of docker cli
 			// https://github.com/balena-os/balena-engine-cli/blob/19.03-balena/opts/gpus.go#L81-L89
 			service.config.deviceRequests.push({
+				Driver: '',
 				Count: 1,
+				DeviceIDs: [],
 				Capabilities: [['gpu']],
+				Options: {},
 			} as Dockerode.DeviceRequest),
 	};
 

--- a/test/04-service.spec.ts
+++ b/test/04-service.spec.ts
@@ -503,8 +503,11 @@ describe('compose/service', () => {
 
 	describe('io.balena.features.gpu: Docker <-> Compose config', () => {
 		const gpuDeviceRequest = {
+			Driver: '',
+			DeviceIDs: [],
 			Count: 1,
 			Capabilities: [['gpu']],
+			Options: {},
 		};
 		it('should succeed from compose object', async () => {
 			const s = await Service.fromComposeObject(


### PR DESCRIPTION
The device request object was created with untouched fields left unset. When
comparing state to determine if a transition is required this would
result in a mismatch between:

    {
      Driver: '',
      Count: 1,
      DeviceIDs: null,
      Capabilities: [Array],
      Options: null
    }

and

    {
      Count: 1,
      Capabilities: [Array],
    }

Which in turn resulted in the target service being continously restarted.
The fix is to instantiate the object in full.

Connects-to: https://github.com/balena-io/balena-supervisor/issues/1449
Connects-to: ae646a07ec6a6c96f7cb91f1d37898a94dbab47a
Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>