### PR TITLE
Prevent inserting null commit during DB migration

### DIFF
--- a/src/migrations/M00006.js
+++ b/src/migrations/M00006.js
@@ -9,7 +9,7 @@ export async function up(knex) {
 	const currentCommit = await knex('config')
 		.where({ key: 'currentCommit' })
 		.select('value');
-	if (currentCommit[0] != null) {
+	if (currentCommit[0] != null && currentCommit[0].value != null) {
 		const apps = await knex('app').select(['appId']);
 
 		for (const app of apps) {


### PR DESCRIPTION
The migration checks if the data it is about to insert is not null but the Supervisor creates a object with a null commit inside. This PR just extends the check to make sure the commit value being inserted isn't null.

Change-type: patch
Closes: #1581
Signed-off-by: Miguel Casqueira <miguel@balena.io>