### PR TITLE
Infer legacy Volumes that do not have the supervised label

### DIFF
--- a/test/28-db-format.spec.ts
+++ b/test/28-db-format.spec.ts
@@ -44,8 +44,8 @@ describe('DB Format', () => {
 				source: apiEndpoint,
 				releaseId: 123,
 				services: '[]',
-				networks: '{}',
-				volumes: '{}',
+				networks: '[]',
+				volumes: '[]',
 			},
 			{
 				appId: 2,
@@ -68,8 +68,8 @@ describe('DB Format', () => {
 						commit: 'abcdef2',
 					},
 				]),
-				networks: '{}',
-				volumes: '{}',
+				networks: '[]',
+				volumes: '[]',
 			},
 		]);
 	});

--- a/test/34-firewall.spec.ts
+++ b/test/34-firewall.spec.ts
@@ -180,8 +180,8 @@ describe('Host Firewall', function () {
 									commit: 'abcdef2',
 								},
 							]),
-							networks: '{}',
-							volumes: '{}',
+							networks: '[]',
+							volumes: '[]',
 						},
 					]);
 
@@ -233,8 +233,8 @@ describe('Host Firewall', function () {
 									commit: 'abcdef2',
 								},
 							]),
-							networks: '{}',
-							volumes: '{}',
+							networks: '[]',
+							volumes: '[]',
 						},
 					]);
 

--- a/test/41-device-api-v1.spec.ts
+++ b/test/41-device-api-v1.spec.ts
@@ -65,8 +65,8 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 			source: 'https://api.balena-cloud.com',
 			releaseId: 1232,
 			services: JSON.stringify(services),
-			networks: '{}',
-			volumes: '{}',
+			networks: '[]',
+			volumes: '[]',
 		});
 	});
 
@@ -326,8 +326,8 @@ describe('SupervisorAPI [V1 Endpoints]', () => {
 				source: 'https://api.balena-cloud.com',
 				releaseId: 1232,
 				services: JSON.stringify([service]),
-				volumes: '{}',
-				networks: '{}',
+				volumes: '[]',
+				networks: '[]',
 			});
 
 			// Perform the test with our mocked release

--- a/test/42-device-api-v2.spec.ts
+++ b/test/42-device-api-v2.spec.ts
@@ -321,8 +321,8 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 				source: 'https://api.balena-cloud.com',
 				releaseId: 1232,
 				services: JSON.stringify([service]),
-				networks: '{}',
-				volumes: '{}',
+				networks: '[]',
+				volumes: '[]',
 			});
 
 			lockMock.reset();
@@ -426,8 +426,8 @@ describe('SupervisorAPI [V2 Endpoints]', () => {
 				source: 'https://api.balena-cloud.com',
 				releaseId: 1232,
 				services: JSON.stringify(mockContainers),
-				networks: '{}',
-				volumes: '{}',
+				networks: '[]',
+				volumes: '[]',
 			});
 
 			lockMock.reset();

--- a/test/44-volume-manager.spec.ts
+++ b/test/44-volume-manager.spec.ts
@@ -1,0 +1,171 @@
+import { expect } from 'chai';
+import { stub, SinonStub } from 'sinon';
+
+import * as mockedDockerode from './lib/mocked-dockerode';
+import * as volumeManager from '../src/compose/volume-manager';
+import log from '../src/lib/supervisor-console';
+import Volume from '../src/compose/volume';
+
+describe('Volume Manager', () => {
+	let logDebug: SinonStub;
+	before(() => {
+		logDebug = stub(log, 'debug');
+	});
+	after(() => {
+		logDebug.restore();
+	});
+
+	afterEach(() => {
+		// Clear Dockerode actions recorded for each test
+		mockedDockerode.resetHistory();
+		logDebug.reset();
+	});
+
+	it('gets all supervised Volumes', async () => {
+		// Setup volume data
+		const volumeData = [
+			createVolumeInspectInfo(Volume.generateDockerName(1, 'redis'), {
+				'io.balena.supervised': '1', // Recently created volumes contain io.balena.supervised label
+			}),
+			createVolumeInspectInfo(Volume.generateDockerName(1, 'mysql'), {
+				'io.balena.supervised': '1', // Recently created volumes contain io.balena.supervised label
+			}),
+			createVolumeInspectInfo(Volume.generateDockerName(1, 'backend')), // Old Volumes will not have labels
+			createVolumeInspectInfo('user_created_volume'), // Volume not created by the Supervisor
+			createVolumeInspectInfo('decoy', { 'io.balena.supervised': '1' }), // Added decoy to really test the inference (should not return)
+		];
+		// Perform test
+		await mockedDockerode.testWithData({ volumes: volumeData }, async () => {
+			await expect(volumeManager.getAll()).to.eventually.deep.equal([
+				{
+					appId: 1,
+					config: {
+						driver: 'local',
+						driverOpts: {},
+						labels: {
+							'io.balena.supervised': '1',
+						},
+					},
+					name: 'redis',
+				},
+				{
+					appId: 1,
+					config: {
+						driver: 'local',
+						driverOpts: {},
+						labels: {
+							'io.balena.supervised': '1',
+						},
+					},
+					name: 'mysql',
+				},
+				{
+					appId: 1,
+					config: {
+						driver: 'local',
+						driverOpts: {},
+						labels: {},
+					},
+					name: 'backend',
+				},
+			]);
+			// Check that debug message was logged saying we found a Volume not created by us
+			expect(logDebug.lastCall.lastArg).to.equal('Cannot parse Volume: decoy');
+		});
+	});
+
+	it('gets a Volume for an application', async () => {
+		// Setup volume data
+		const volumeData = [
+			createVolumeInspectInfo(Volume.generateDockerName(111, 'app'), {
+				'io.balena.supervised': '1',
+			}),
+			createVolumeInspectInfo(Volume.generateDockerName(222, 'otherApp'), {
+				'io.balena.supervised': '1',
+			}),
+		];
+		// Perform test
+		await mockedDockerode.testWithData({ volumes: volumeData }, async () => {
+			await expect(volumeManager.getAllByAppId(111)).to.eventually.deep.equal([
+				{
+					appId: 111,
+					config: {
+						driver: 'local',
+						driverOpts: {},
+						labels: {
+							'io.balena.supervised': '1',
+						},
+					},
+					name: 'app',
+				},
+			]);
+		});
+	});
+
+	it('creates a Volume', async () => {
+		// Setup volume data
+		const volumeData: Dictionary<any> = [];
+		// Perform test
+		await mockedDockerode.testWithData({ volumes: volumeData }, async () => {
+			// Volume to create
+			const volume = Volume.fromComposeObject('main', 111, {});
+			stub(volume, 'create');
+			// Create volume
+			await volumeManager.create(volume);
+			// Check volume was created
+			expect(volume.create as SinonStub).to.be.calledOnce;
+		});
+	});
+
+	it('does not try to create a volume that already exists', async () => {
+		// Setup volume data
+		const volumeData = [
+			createVolumeInspectInfo(Volume.generateDockerName(111, 'main'), {
+				'io.balena.supervised': '1',
+			}),
+		];
+		// Perform test
+		await mockedDockerode.testWithData({ volumes: volumeData }, async () => {
+			// Volume to try again create
+			const volume = Volume.fromComposeObject('main', 111, {});
+			stub(volume, 'create');
+			// Create volume
+			await volumeManager.create(volume);
+			// Check volume was not created
+			expect(volume.create as SinonStub).to.not.be.called;
+		});
+	});
+
+	it('removes a Volume', async () => {
+		// Setup volume data
+		const volumeData = [
+			createVolumeInspectInfo(Volume.generateDockerName(111, 'main'), {
+				'io.balena.supervised': '1',
+			}),
+		];
+		// Perform test
+		await mockedDockerode.testWithData({ volumes: volumeData }, async () => {
+			// Volume to remove
+			const volume = Volume.fromComposeObject('main', 111, {});
+			stub(volume, 'remove');
+			// Remove volume
+			await volumeManager.remove(volume);
+			// Check volume was removed
+			expect(volume.remove as SinonStub).to.be.calledOnce;
+		});
+	});
+});
+
+function createVolumeInspectInfo(
+	name: string,
+	labels: { [key: string]: string } = {},
+	driver: string = 'local',
+	options: { [key: string]: string } | null = null,
+) {
+	return {
+		Name: name,
+		Driver: driver,
+		Labels: labels,
+		Options: options,
+	};
+}


### PR DESCRIPTION
I spent a bit of time trying to figure out what the least impactful way to make the Supervisor detect Volumes without the supervised label. This fix solves that by using existing functions namely,  `deconstructDockerName` which tries to extract Volume info such as appId from a given volume ID. If the Supervisor cannot extract info from a Volume's inspect info which it created then it can assume that volume was not created by the Supervisor. Therefore, this patch allows the Supervisor to detect such legacy volumes and also logs whenever a Volume is not supervised to help with troubleshooting in the future if the Supervisor is ignoring a volume.

Change-type: patch
Closes: #1604
Signed-off-by: Miguel Casqueira <miguel@balena.io>